### PR TITLE
Add autoformat support and fix error reporting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+autopep8
 flake8
 mccabe
 mistletoe


### PR DESCRIPTION
Before if it reached the end of the retry list where it returned a response that conforms to markdown but still doesn't work, it would exit as if it was successful.
