### PR TITLE
Parallelize the first stage

### DIFF
--- a/marsha.py
+++ b/marsha.py
@@ -19,6 +19,7 @@ parser = argparse.ArgumentParser(
     description='Marsha AI Compiler',
 )
 parser.add_argument('source')
+parser.add_argument('-d', '--debug', action='store_true', help='Turn on debug logging')
 args = parser.parse_args()
 
 
@@ -40,12 +41,40 @@ async def main():
     func = f.read()
     f.close()
     files = write_files_from_markdown(await gpt_func_to_python(func))
+    if args.debug:
+        for file in files:
+            print(file)
+            f = open(file, 'r')
+            print(f.read())
+            f.close()
+            print()
     print('Parsing generated code...')
     await lint_and_fix_files(files)
+    if args.debug:
+        for file in files:
+            print(file)
+            f = open(file, 'r')
+            print(f.read())
+            f.close()
+            print()
     print('Verifying and correcting generated code...')
     await test_and_fix_files(func, files)
+    if args.debug:
+        for file in files:
+            print(file)
+            f = open(file, 'r')
+            print(f.read())
+            f.close()
+            print()
     print('Formatting code...')
     autoformat_files(files)
+    if args.debug:
+        for file in files:
+            print(file)
+            f = open(file, 'r')
+            print(f.read())
+            f.close()
+            print()
     t2 = time.time()
     print(f'Done! Total time elapsed: {prettify_time_delta(t2 - t1)}')
 


### PR DESCRIPTION
Parallelizing the first stage returns results in approximately half the time, which is really good.

It also produces "better" unit test code (from comparing a small sample size of the two tests cases I currently have vs current main). Made this easier by adding a `-d` debug flag to print the files between each stage of the compiler.

Unfortunately, the third stage appears to be slower because it apparently has more corrections to make to the code it generated than before. I will see if I can have my cake and eat it, too, with some tweaking to the code generation prompt, but probably in a follow-up PR.
