### PR TITLE
Handle one error at a time

### DIFF
--- a/llm.py
+++ b/llm.py
@@ -327,7 +327,6 @@ async def test_and_fix_files(func, files, max_depth=8):
             pass
         raise
     test_results = f'''{stdout.decode('utf-8')}{stderr.decode('utf-8')}'''
-    print(test_results)
 
     # Recursively work on fixing the files while the test suite fails, return when complete
     if "FAILED" in test_results or "Traceback" in test_results:


### PR DESCRIPTION
Also, make sure we parse the stdout/stderr as utf-8 to avoid unnecessary quoting being handed to ChatGPT which may have impacted it's ability to handle the error messages
