### PR TITLE
Add query builder example

### DIFF
--- a/examples/sql/query-builder.mrsh
+++ b/examples/sql/query-builder.mrsh
@@ -1,0 +1,3 @@
+# func get_most_populated_cities(): postgres sql query generated
+
+This function generates a postgresql query to retrieve all columns for the TOP 5 cities from the 'city' table with the highest 'population'

--- a/examples/sql/query-builder.mrsh
+++ b/examples/sql/query-builder.mrsh
@@ -1,3 +1,8 @@
+<!--- 
+  The code generated could be used as follows with `psql`:
+  python -m query-builder | xargs psql postgres://sqlpaluser:sqlpass@localhost:5432/sqlpal -c
+--->
+
 # func get_most_populated_cities(): postgres sql query generated
 
 This function generates a postgresql query to retrieve all columns for the TOP 5 cities from the 'city' table with the highest 'population'


### PR DESCRIPTION
Rather than the example, the most interesting part is how it can be used:

```bash
python -m query-builder | xargs psql postgres://sqlpaluser:sqlpass@localhost:5432/sqlpal -c
```