### PR TITLE
Add a sanity check to incoming Marsha functions

### DIFF
--- a/examples/general-purpose/lol.mrsh
+++ b/examples/general-purpose/lol.mrsh
@@ -1,0 +1,8 @@
+<!-- This is an example of a *bad* Marsha function. There is nowhere near enough information for Marsha to do something reasonable with this, and marsha will reject it. -->
+
+# func facebook(user request) facebook page
+
+Make facebook for me
+
+* facebook('home') = My facebook homepage
+* facebook('my friend') = My friend's facebook page

--- a/marsha/base.py
+++ b/marsha/base.py
@@ -5,8 +5,9 @@ import openai
 import tempfile
 import time
 import traceback
+import sys
 
-from marsha.llm import gpt_func_to_python, lint_and_fix_files, test_and_fix_files, prettify_time_delta
+from marsha.llm import gpt_can_func_python, gpt_improve_func, gpt_func_to_python, lint_and_fix_files, test_and_fix_files, prettify_time_delta
 from marsha.parse import extract_functions_and_types, extract_type_name, write_files_from_markdown, is_defined_from_file, extract_type_filename
 from marsha.utils import read_file, write_file, autoformat_files, copy_file, get_filename_from_path, add_helper, copy_tree
 
@@ -28,6 +29,8 @@ parser.add_argument('-a', '--attempts', type=int, default=1)
 parser.add_argument('-n', '--n-parallel-executions', type=int, default=3)
 parser.add_argument('--exclude-main-helper', action='store_true',
                     help='Skips addition of helper code for running as a script')
+parser.add_argument('--exclude-sanity-check', action='store_true',
+                    help='Skips an initial sanity check that function defintions will reliably generate working code')
 parser.add_argument('-s', '--stats', action='store_true',
                     help='Save stats and write them to a file')
 
@@ -143,7 +146,7 @@ async def main():
         try:
             mds = await generate_python_code(
                 marsha_filename, functions, types_defined, void_funcs, n_results, debug, stats)
-        except Exception as e:
+        except Exception:
             continue
         # Early exit if quick and dirty
         if quick_and_dirty:
@@ -241,6 +244,10 @@ async def generate_python_code(marsha_filename: str, functions: list[str], types
     print('Generating Python code...')
     mds = None
     try:
+        if not args.exclude_sanity_check:
+            if not await gpt_can_func_python(marsha_filename, functions, types_defined, void_funcs, n_results, stats, debug=debug):
+                await gpt_improve_func(marsha_filename, functions, types_defined, void_funcs, n_results, stats, debug=debug)
+                sys.exit(1)
         mds = await gpt_func_to_python(marsha_filename, functions, types_defined, void_funcs, n_results, stats, debug=debug)
     except Exception as e:
         print('First stage failure')
@@ -370,5 +377,5 @@ def cleanup_tmp_directories(tmp_directories: list):
     for tmp_directory in tmp_directories:
         try:
             tmp_directory.cleanup()
-        except:
+        except Exception:
             pass

--- a/marsha/llm.py
+++ b/marsha/llm.py
@@ -10,7 +10,7 @@ import time
 
 from pylama.main import parse_options, check_paths, DEFAULT_FORMAT
 
-from marsha.parse import validate_first_stage_markdown, validate_second_stage_markdown, write_files_from_markdown, format_marsha_for_llm, extract_func_name, extract_type_name
+from marsha.parse import validate_first_stage_markdown, validate_second_stage_markdown, write_files_from_markdown, format_marsha_for_llm, extract_func_name
 from marsha.utils import read_file
 
 # OpenAI pricing model.
@@ -92,6 +92,56 @@ async def retry_chat_completion(query, model='gpt-3.5-turbo', max_tries=3, n_res
             raise Exception('Could not execute chat completion')
 
 
+async def gpt_can_func_python(marsha_filename: str, functions: list[str], defined_types: list[str], void_funcs: list[str], n_results: int, stats: dict, retries: int = 3, debug: bool = False):
+    marsha_for_code_llm = format_marsha_for_llm(
+        marsha_filename, functions + void_funcs, defined_types)
+    res = await retry_chat_completion({
+        'messages': [{
+            'role': 'system',
+            'content': '''You are a senior software engineer reviewing an assignment to write a Python 3 function.
+The assignment is written in markdown format.
+It should include sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
+You are assessing if this document has enough context such that a junior software engineer with a couple of years of experience should be able to write the desired function and a test suite to verify it.
+The description must be precise enough to determine what to do.
+The examples must be complete enough to likely catch all edge cases.
+If the description and examples are broad enough that different engineers could reasonably create very different functions that supposedly meet the requirements but do different things, that is another reason to reject this assignment.
+Your answer is consumed by project management software, so only respond with Y for yes or N for no.
+''',
+        }, {
+            'role': 'user',
+            'content': f'''{marsha_for_code_llm}'''
+        }],
+        'max_tokens': 1,
+    }, n_results=n_results)
+    if any([True if choice.message.content == 'N' else False for choice in res.choices]):
+        return False
+    return True
+
+
+async def gpt_improve_func(marsha_filename: str, functions: list[str], defined_types: list[str], void_funcs: list[str], stats: dict, retries: int = 3, debug: bool = False):
+    marsha_for_code_llm = format_marsha_for_llm(
+        marsha_filename, functions + void_funcs, defined_types)
+    res = await retry_chat_completion({
+        'messages': [{
+            'role': 'system',
+            'content': '''You are a senior software engineer reviewing an assignment to write a Python 3 function that a junior software engineer has written.
+The assignment is written in markdown format.
+It includes sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
+You have already decided this document is not written well enough such that another engineer can reliably write a working function that meets expectations, nor a test suite to verify proper functionality.
+The description must be precise enough to determine what to do.
+The examples must be complete enough to likely catch all edge cases.
+You are writing a few paragraphs gently explaining the deficiencies in the task definition they have written, not coming up with examples assuming what they might have wanted, since that isn't clear in the first place, just why what they have provided is not precise enough.
+In your response do not refer to the person at all or tell them what mistakes "they" have made. This is a blameless culture. The mistakes simply are, and that they made them isn't a problem, just that they should learn from them.
+Do not include a "hello" or a "regards", etc, as your response is being attached to a code review system.
+''',
+        }, {
+            'role': 'user',
+            'content': f'''{marsha_for_code_llm}'''
+        }],
+    })
+    print(res.choices[0].message.content)
+
+
 async def gpt_func_to_python(marsha_filename: str, functions: list[str], defined_types: list[str], void_funcs: list[str], n_results: int, stats: dict, retries: int = 3, debug: bool = False):
     marsha_for_code_llm = format_marsha_for_llm(
         marsha_filename, functions + void_funcs, defined_types)
@@ -106,7 +156,7 @@ async def gpt_func_to_python(marsha_filename: str, functions: list[str], defined
     reses = await asyncio.gather(retry_chat_completion({
         'messages': [{
             'role': 'system',
-            'content': f'''You are a senior software engineer assigned to write Python 3 functions. 
+            'content': f'''You are a senior software engineer assigned to write Python 3 functions.
 The assignment is written in markdown format.
 The description of each function should be included as a docstring.
 Add type hints if feasible.


### PR DESCRIPTION
This runs one short LLM call that flags `.mrsh` files that are not complete enough to generate a reliable output and provides feedback on why to the user.

```sh
damocles@elack:~/alantech/marsha/examples/general-purpose(main)$ marsha lol.mrsh
Compiling functions for lol...
Generating Python code...
Chat query took 573.099ms, started at 1.69897ms, ms/chars = 2.256295812411571
Chat query took  9sec 633.19ms, started at 575.091ms, ms/chars = 14.981633582345063
Thank you for providing the requirements for the `facebook` function. However, there are a few deficiencies in the task definition that make it difficult to understand what the function should actually do.

Firstly, the input parameter is defined as "user request." It would be helpful to clarify what exactly should be passed as the "user request" parameter. Is it a string representing a specific action or information? Or is it an object containing various properties? Providing more details about the expected input would be beneficial.

Secondly, the output is defined as "None." It's important to specify what the function should return. Should it return a string containing some information or a specific value? Without a clear definition of the expected output, it is challenging to understand how the function should behave.

Lastly, the description simply states "Make facebook for me." It would be beneficial to provide a more detailed explanation of what the function should accomplish. What specific functionality should be implemented? Should the function interact with an API, perform database operations, or generate specific content? Providing additional context will help in accurately implementing the function.

Additionally, the provided examples are not sufficient to cover all possible scenarios and edge cases. It would be helpful to include more examples that cover different scenarios, such as providing a specific user's Facebook page or performing a specific action on Facebook.

In summary, to improve the clarity of the task definition, please provide more specific details about the input, clarify the expected output, and include a more detailed description of the desired functionality. Additionally, consider providing additional examples to cover a wider range of scenarios.
damocles@elack:~/alantech/marsha/examples/general-purpose(main)$
```

You can disable this behavior with the new `--exclude-sanity-check` flag, though it *does* fail to make Facebook for me 🤪

```sh
damocles@elack:~/alantech/marsha/examples/general-purpose(main)$ marsha --exclude-sanity-check lol.mrsh
Compiling functions for lol...
Generating Python code...
Chat query took  3sec 18.6808ms, started at 1.78003ms, ms/chars = 4.636990492977488
Chat query took  6sec 114.434ms, started at 6.21819ms, ms/chars = 9.071861247280586
Chat query took  2sec 482.685ms, started at  6sec 122.2ms, ms/chars = 4.1309232124671365
Chat query took 18sec 635.231ms, started at  6sec 122.727ms, ms/chars = 19.636702361674654
Chat query took  3sec 817.989ms, started at 24sec 764.354ms, ms/chars = 5.837903474813572
Chat query took 15sec 309.977ms, started at 24sec 765.778ms, ms/chars = 10.97489411685629
Chat query took  3sec 396.342ms, started at 40sec 84.4588ms, ms/chars = 5.282024202598939
Chat query took 18sec 102.126ms, started at 40sec 85.8586ms, ms/chars = 16.133802247344917
First stage failure
('Failed to generate code', 'lol')
Retrying...
Traceback (most recent call last):
  File "marsha/__main__.py", line 6, in <module>
  File "asyncio/runners.py", line 44, in run
  File "asyncio/base_events.py", line 646, in run_until_complete
  File "marsha/base.py", line 222, in main
Exception: Failed to generate working code for lol. Total time elapsed: 58sec 196.262ms. Total cost: 0.05.
[98551] Failed to execute script '__main__' due to unhandled exception!
damocles@elack:~/alantech/marsha/examples/general-purpose(main)$
```

I am also thinking of having an `--only-sanity-check` flag that could be used to check what has been written so far, but not try to compile it in case the user doesn't want to do that, but I'm not sure if/when that sort of situation would occur (it just seems reasonable to allow the feature to be orthogonal to the main compile path).
