### PR TITLE
Add GET support for zero arg functions

### DIFF
--- a/examples/general-purpose/now.mrsh
+++ b/examples/general-purpose/now.mrsh
@@ -1,0 +1,7 @@
+# func now(): the current date and time
+
+This function prints the current date and time in an english format. It includes the day of the week, month, day, and year for the date. For the time it incldues the hour, minute, AM/PM, and timezone.
+
+* now() = 'Today is Wednesday, August 2nd, 2023. It is currently 5:19PM CDT'
+* now() = 'Today is Monday, July 31st, 2023. It is currently 8:37AM CDT'
+* now() = 'Today is Sunday, January 20th, 2019. It is currently 3:14PM PST'

--- a/marsha/helper.py
+++ b/marsha/helper.py
@@ -29,6 +29,29 @@ if __name__ == '__main__':
         from http.server import BaseHTTPRequestHandler, HTTPServer
 
         class MarshaServer(BaseHTTPRequestHandler):
+            def do_GET(self):
+                func_name = self.path.split('/')[1]
+                if func_name not in func_names:
+                    self.send_response(404)
+                    self.send_header('Content-Type', 'application/json')
+                    self.end_headers()
+                    self.wfile.write(
+                        bytes('{"error": "' + self.path + ' does not exist"}', 'utf-8'))
+                    return
+                func = lookup[func_name]
+                if func.__code__.co_argcount != 0:
+                    self.send_response(400)
+                    self.send_header('Content-Type', 'application/json')
+                    self.end_headers()
+                    self.wfile.write(
+                        bytes('{"error": "' + self.path + ' is not a GET path"}', 'utf-8'))
+                    return
+                out = func()
+                self.send_response(200)
+                self.send_header('Content-Type', 'application/json')
+                self.end_headers()
+                self.wfile.write(bytes(json.dumps(out), 'utf-8'))
+
             def do_POST(self):
                 func_name = self.path.split('/')[1]
                 if func_name not in func_names:


### PR DESCRIPTION
With a new `now.mrsh` script, I can run it's output with:

```sh
$ python now.py -s 8888
```

and on another shell curl it.

```sh
$ curl http://localhost:8888/now
"Today is Wednesday, August 2nd, 2023. It is currently 10:15PM CDT"
```

Demonstrating that the new helper code properly handles GET requests for zero-argument functions.
