### PR TITLE
Mappers

### DIFF
--- a/marsha/.time.py
+++ b/marsha/.time.py
@@ -5,7 +5,7 @@ import math
 import os
 import time
 
-from marsha.llm import prettify_time_delta
+from marsha.utils import prettify_time_delta
 
 from mistletoe import Document, ast_renderer
 
@@ -42,7 +42,7 @@ for i in range(total_runs):
             run_stats_file = open('stats.md', 'r')
             run_stats = run_stats_file.read()
             run_stats_file.close()
-        except Exception as e:
+        except Exception:
             raise Exception('Error reading stats file. Maybe something went run while running Marsha and the stats were not generated?')
         try:
             ast = ast_renderer.get_ast(Document(run_stats))

--- a/marsha/base.py
+++ b/marsha/base.py
@@ -7,10 +7,10 @@ import time
 import traceback
 import sys
 
-from marsha.llm import gpt_can_func_python, gpt_improve_func, gpt_func_to_python, lint_and_fix_files, test_and_fix_files, prettify_time_delta
+from marsha.llm import gpt_can_func_python, gpt_improve_func, gpt_func_to_python, lint_and_fix_files, test_and_fix_files
 from marsha.parse import extract_functions_and_types, extract_type_name, write_files_from_markdown, is_defined_from_file, extract_type_filename
 from marsha.stats import MarshaStats
-from marsha.utils import read_file, autoformat_files, copy_file, get_filename_from_path, add_helper, copy_tree
+from marsha.utils import read_file, autoformat_files, copy_file, get_filename_from_path, add_helper, copy_tree, prettify_time_delta
 
 # Set up OpenAI
 openai.organization = os.getenv('OPENAI_ORG')

--- a/marsha/basemapper.py
+++ b/marsha/basemapper.py
@@ -1,0 +1,31 @@
+class BaseMapper():
+    """Semi-abstract base for 'mappers' in Marsha"""
+
+    def __init__(self):
+        self.check_retries = 3
+        self.output = None
+
+    async def transform(self, i):
+        raise Exception('Not implemented')
+
+    async def check(self):
+        # Define a check if you want, but not necessary
+        return self.output
+
+    async def run(self, i):
+        try:
+            self.output = await self.transform(i)
+        except Exception as e:
+            # TODO: Log the error before re-raise?
+            raise e
+
+        iters = self.check_retries
+        while iters > 0:
+            try:
+                o = await self.check()
+                return o
+            except Exception:
+                # Using the exception here as flow control
+                iters = iters - 1
+
+        raise Exception('Transformer failed to converge')

--- a/marsha/chatgptmapper.py
+++ b/marsha/chatgptmapper.py
@@ -1,0 +1,64 @@
+import openai
+import time
+
+from marsha.basemapper import BaseMapper
+from marsha.utils import prettify_time_delta
+
+# Get time at startup to make human legible "start times" in the logs
+t0 = time.time()
+
+
+async def retry_chat_completion(query, model='gpt-3.5-turbo', max_tries=3, n_results=1):
+    t1 = time.time()
+    query['model'] = model
+    query['n'] = n_results
+    while True:
+        try:
+            out = await openai.ChatCompletion.acreate(**query)
+            t2 = time.time()
+            print(
+                f'''Chat query took {prettify_time_delta(t2 - t1)}, started at {prettify_time_delta(t1 - t0)}, ms/chars = {(t2 - t1) * 1000 / out.get('usage', {}).get('total_tokens', 9001)}''')
+            return out
+        except openai.error.InvalidRequestError as e:
+            if e.code == 'context_length_exceeded':
+                # Try to cover up this error by choosing the bigger, more expensive model
+                query['model'] = 'gpt-4'
+            max_tries = max_tries - 1
+            if max_tries == 0:
+                raise e
+            time.sleep(3 / max_tries)
+        except Exception as e:
+            max_tries = max_tries - 1
+            if max_tries == 0:
+                raise e
+            time.sleep(3 / max_tries)
+        if max_tries == 0:
+            raise Exception('Could not execute chat completion')
+
+
+class ChatGPTMapper(BaseMapper):
+    """ChatGPT-based mapper class"""
+
+    def __init__(self, system, model='gpt-3.5-turbo', max_tokens=None, max_retries=3, n_results=1):
+        BaseMapper.__init__(self)
+        self.system = system
+        self.model = model
+        self.max_tokens = max_tokens
+        self.max_retries = max_retries
+        self.n_results = n_results
+
+    async def transform(self, user_request):
+        query_obj = {
+            'messages': [{
+                'role': 'system',
+                'content': self.system,
+            }, {
+                'role': 'user',
+                'content': user_request,
+            }],
+        }
+        if self.max_tokens is not None:
+            query_obj['max_tokens'] = self.max_tokens
+        res = await retry_chat_completion(query_obj, self.model, self.max_retries, self.n_results)
+
+        return [choice.message.content for choice in res.choices] if self.n_results > 1 else res.choices[0].message.content

--- a/marsha/utils.py
+++ b/marsha/utils.py
@@ -4,6 +4,30 @@ import os
 import shutil
 
 
+def prettify_time_delta(delta, max_depth=2):
+    rnd = round if max_depth == 1 else int
+    if not max_depth:
+        return ''
+    if delta < 1:
+        return f'''{format(delta * 1000, '3g')}ms'''
+    elif delta < 60:
+        sec = rnd(delta)
+        subdelta = delta - sec
+        return f'''{format(sec, '2g')}sec {prettify_time_delta(subdelta, max_depth - 1)}'''.rstrip()
+    elif delta < 3600:
+        mn = rnd(delta / 60)
+        subdelta = delta - mn * 60
+        return f'''{format(mn, '2g')}min {prettify_time_delta(subdelta, max_depth - 1)}'''.rstrip()
+    elif delta < 86400:
+        hr = rnd(delta / 3600)
+        subdelta = delta - hr * 3600
+        return f'''{format(hr, '2g')}hr {prettify_time_delta(subdelta, max_depth - 1)}'''.rstrip()
+    else:
+        day = rnd(delta / 86400)
+        subdelta = delta - day * 86400
+        return f'''{format(day, '2g')}days {prettify_time_delta(subdelta, max_depth - 1)}'''.rstrip()
+
+
 def read_file(filename: str, mode: str = 'r'):
     with open(filename, mode) as f:
         content = f.read()


### PR DESCRIPTION
Started work on the refactoring RFC. Today's progress is just using it as a thin wrapper on top of the GPT calling logic and doesn't really provide a benefit.

Next steps will be creating Mappers for the other transformations in the codebase and moving most of the logic out of `llm.py`, reviving the stats tracking logic (probably automatically within the `ChatGPTMapper`), and then pulling logic out of `base.py` into `llm.py` and start refactoring said logic into the layers of transformations.

This PR is fully functional (besides the stats tracking, which shouldn't be too hard) and could be merged once stats are back, but it could also be a longer-lived branch if we want to wait for the RFC to be merged first.
