### PR TITLE
Configurable LLM endpoint and modern OpenAI client (Llama.cpp support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ options:
   --exclude-main-helper
                         Skips addition of helper code for running as a script
   --exclude-sanity-check
-                        Skips an initial sanity check that function defintions
-                        will reliably generate working code
+                        Skips an initial sanity check that the definition is
+                        self-consistent
   -s, --stats           Save stats and write them to a file
   --api-base API_BASE   Base URL of an OpenAI-compatible API to use for LLM
                         requests, e.g. a local llama.cpp server. Overrides the

--- a/README.md
+++ b/README.md
@@ -103,11 +103,13 @@ In order to use the compiler, Marsha needs to know which LLM to send requests to
 
 Any OpenAI-compatible API can be used instead, such as the server that ships with [llama.cpp](https://github.com/ggml-org/llama.cpp) for running models locally. The endpoint can be configured with the `--api-base` command line flag, the `OPENAI_BASE_URL` environment variable, or a config file, in that order of precedence.
 
-The config file is a JSON file with the keys `api_base` and `api_key`, read from the standard configuration location for your OS:
+The config file is a JSON file read from the standard configuration location for your OS:
 
 * Linux: `~/.config/marsha/config.json` (or `$XDG_CONFIG_HOME/marsha/config.json` if that is set)
 * macOS: `~/Library/Application Support/marsha/config.json`
 * Windows: `%LOCALAPPDATA%\marsha\config.json`
+
+It supports the keys `api_base`, `api_key`, `model`, and `model_strong`. The default model for code generation is `gpt-5-mini`; `model_strong` (default `gpt-5`) is used for the test-fixing stage and as the escalation target when a prompt exceeds the model's context.
 
 Eg, to point Marsha at a llama.cpp server listening on localhost port 8080:
 
@@ -126,7 +128,7 @@ There are also a few flags on how to use Marsha:
 $ marsha --help
 usage: marsha [-h] [-d] [-q] [-a ATTEMPTS] [-n N_PARALLEL_EXECUTIONS]
               [--exclude-main-helper] [--exclude-sanity-check] [-s]
-              [--api-base API_BASE]
+              [--api-base API_BASE] [--model MODEL]
               source
 
 Marsha AI Compiler
@@ -151,6 +153,8 @@ options:
                         requests, e.g. a local llama.cpp server. Overrides the
                         OPENAI_BASE_URL environment variable and the config
                         file
+  --model MODEL         Model to use for code generation, overriding the model
+                        in the config file
 ```
 
 * `-d` adds a significant amount of debug information to the screen. Probably not useful if you're not working on Marsha itself.
@@ -160,6 +164,7 @@ options:
 * `-s` Save the stats that are printed by default to a file, instead. Probably not useful if you're not working on Marsha itself.
 * `--exclude-main-helper` Turns off the automatically generated code to make using your compiled Marsha code from the CLI easier, which is included by default.
 * `--api-base` Overrides the LLM endpoint with the base URL of any OpenAI-compatible API (eg `http://localhost:8080/v1` for a llama.cpp server). Takes precedence over the `OPENAI_BASE_URL` environment variable and the config file.
+* `--model` Overrides the model used for code generation (default `gpt-5-mini`), eg to use a different OpenAI model or the name of a locally served model.
 
 ## Using compiled Marsha code
 

--- a/README.md
+++ b/README.md
@@ -96,18 +96,38 @@ The Marsha syntax is meant to be:
 
 Marsha is compiled by an LLM into tested software that meets the requirements described, but implementation details can vary greatly across runs much like if different developers implemented it for you. There is typically more than one way to write software that fulfills a set of requirements. However, the compiler is best-effort and sometimes it will fail to generate the described program. We aim for 80%+ accuracy on our [examples](./examples/). In general, the more detailed the description and the more examples are provided the more likely the output will work.
 
-In order to use the compiler, the following environment variables must be set:
+In order to use the compiler, Marsha needs to know which LLM to send requests to. By default it uses the OpenAI API, which requires the following environment variables to be set:
 
 * `OPENAI_ORG`
-* `OPENAI_SECRET_KEY`
+* `OPENAI_SECRET_KEY` (or `OPENAI_API_KEY`)
 
-Support for other LLMs, including running something locally, is planned but not yet implemented.
+Any OpenAI-compatible API can be used instead, such as the server that ships with [llama.cpp](https://github.com/ggml-org/llama.cpp) for running models locally. The endpoint can be configured with the `--api-base` command line flag, the `OPENAI_BASE_URL` environment variable, or a config file, in that order of precedence.
+
+The config file is a JSON file with the keys `api_base` and `api_key`, read from the standard configuration location for your OS:
+
+* Linux: `~/.config/marsha/config.json` (or `$XDG_CONFIG_HOME/marsha/config.json` if that is set)
+* macOS: `~/Library/Application Support/marsha/config.json`
+* Windows: `%LOCALAPPDATA%\marsha\config.json`
+
+Eg, to point Marsha at a llama.cpp server listening on localhost port 8080:
+
+```json
+{
+    "api_base": "http://localhost:8080/v1",
+    "api_key": "sk-local"
+}
+```
+
+The key can be anything; local servers like llama.cpp do not validate it.
 
 There are also a few flags on how to use Marsha:
 
 ```sh
 $ marsha --help
-usage: marsha [-h] [-d] [-q] [-a ATTEMPTS] [-n N_PARALLEL_EXECUTIONS] [--exclude-main-helper] [-s] source
+usage: marsha [-h] [-d] [-q] [-a ATTEMPTS] [-n N_PARALLEL_EXECUTIONS]
+              [--exclude-main-helper] [--exclude-sanity-check] [-s]
+              [--api-base API_BASE]
+              source
 
 Marsha AI Compiler
 
@@ -123,7 +143,14 @@ options:
   -n N_PARALLEL_EXECUTIONS, --n-parallel-executions N_PARALLEL_EXECUTIONS
   --exclude-main-helper
                         Skips addition of helper code for running as a script
+  --exclude-sanity-check
+                        Skips an initial sanity check that function defintions
+                        will reliably generate working code
   -s, --stats           Save stats and write them to a file
+  --api-base API_BASE   Base URL of an OpenAI-compatible API to use for LLM
+                        requests, e.g. a local llama.cpp server. Overrides the
+                        OPENAI_BASE_URL environment variable and the config
+                        file
 ```
 
 * `-d` adds a significant amount of debug information to the screen. Probably not useful if you're not working on Marsha itself.
@@ -132,6 +159,7 @@ options:
 * `-n` The number of parallel LLM threads of "thought" to pursue per attempt. This defaults to 3. When a path succeeds, all of the other paths are cancelled.
 * `-s` Save the stats that are printed by default to a file, instead. Probably not useful if you're not working on Marsha itself.
 * `--exclude-main-helper` Turns off the automatically generated code to make using your compiled Marsha code from the CLI easier, which is included by default.
+* `--api-base` Overrides the LLM endpoint with the base URL of any OpenAI-compatible API (eg `http://localhost:8080/v1` for a llama.cpp server). Takes precedence over the `OPENAI_BASE_URL` environment variable and the config file.
 
 ## Using compiled Marsha code
 

--- a/examples/general-purpose/now.mrsh
+++ b/examples/general-purpose/now.mrsh
@@ -1,6 +1,6 @@
 # func now(): the current date and time
 
-This function prints the current date and time in an english format. It includes the day of the week, month, day, and year for the date. For the time it incldues the hour, minute, AM/PM, and timezone.
+This function returns the current date and time in an english format. It includes the day of the week, month, day, and year for the date. For the time it includes the hour, minute, AM/PM, and timezone.
 
 * now() = 'Today is Wednesday, August 2nd, 2023. It is currently 5:19PM CDT'
 * now() = 'Today is Monday, July 31st, 2023. It is currently 8:37AM CDT'

--- a/examples/general-purpose/sort_modules.mrsh
+++ b/examples/general-purpose/sort_modules.mrsh
@@ -6,7 +6,7 @@ The function determines an ordering from these "root" modules to the dependent m
 
 In the case that the dependencies defined are *not* a DAG, it should raise an error describing the cycle found.
 
-* sort_modules([{"name": "a", "dependencies": []}, {"name": "b", "dependencies": ["c"]}, {"name": "c", "dependencies": ["a"]}) = ["a", "c", "b"]
+* sort_modules([{"name": "a", "dependencies": []}, {"name": "b", "dependencies": ["c"]}, {"name": "c", "dependencies": ["a"]}]) = ["a", "c", "b"]
 * sort_modules([{"name": "first_root", "dependencies": []}, {"name": "mid_node", "dependencies": ["first_root", "second_root"]}, {"name": "leaf", "dependencies": ["mid_node", "second_root"]}, {"name": "second_root", "dependencies": []}]) = ["first_root", "second_root", "mid_node", "leaf"]
 * sort_modules([{"name": "a", "dependencies": ["a"]}]) raises an error with the message: "Cycle detected: a -> a"
 * sort_modules([{"name": "a", "dependencies": ["b"]}, {"name": "b", "dependencies": ["c"]}, {"name": "c", "dependencies": ["a"]}]) raises an error with the message: "Cycle detected: a -> b -> c -> a"

--- a/marsha/base.py
+++ b/marsha/base.py
@@ -5,6 +5,7 @@ import tempfile
 import time
 import traceback
 
+from marsha.config import resolve_model, set_cli_model
 from marsha.llm import generate_python_code, review_and_fix
 from marsha.llm_client import create_client, set_client
 from marsha.meta import MarshaMeta
@@ -32,14 +33,18 @@ parser.add_argument('-s', '--stats', action='store_true',
                     help='Save stats and write them to a file')
 parser.add_argument('--api-base',
                     help='Base URL of an OpenAI-compatible API to use for LLM requests, e.g. a local llama.cpp server. Overrides the OPENAI_BASE_URL environment variable and the config file')
+parser.add_argument('--model',
+                    help='Model to use for code generation, overriding the model in the config file')
 
 args = parser.parse_args()
 
 # Set up the shared LLM client
+set_cli_model(args.model)
 client = create_client(args.api_base)
 set_client(client)
 if args.debug:
     print(f'Using LLM endpoint: {client.base_url}')
+    print(f'Using LLM model: {resolve_model()}')
 
 
 async def main():

--- a/marsha/base.py
+++ b/marsha/base.py
@@ -1,20 +1,16 @@
 import argparse
 import asyncio
 import os
-import openai
 import tempfile
 import time
 import traceback
 
 from marsha.llm import generate_python_code, review_and_fix
+from marsha.llm_client import create_client, set_client
 from marsha.meta import MarshaMeta
 from marsha.parse import write_files_from_markdown
 from marsha.stats import stats
 from marsha.utils import read_file, copy_file, add_helper, copy_tree, prettify_time_delta
-
-# Set up OpenAI
-openai.organization = os.getenv('OPENAI_ORG')
-openai.api_key = os.getenv('OPENAI_SECRET_KEY')
 
 # Parse the input arguments
 parser = argparse.ArgumentParser(
@@ -36,6 +32,9 @@ parser.add_argument('-s', '--stats', action='store_true',
                     help='Save stats and write them to a file')
 
 args = parser.parse_args()
+
+# Set up the shared LLM client
+set_client(create_client())
 
 
 async def main():

--- a/marsha/base.py
+++ b/marsha/base.py
@@ -28,7 +28,7 @@ parser.add_argument('-n', '--n-parallel-executions', type=int, default=3)
 parser.add_argument('--exclude-main-helper', action='store_true',
                     help='Skips addition of helper code for running as a script')
 parser.add_argument('--exclude-sanity-check', action='store_true',
-                    help='Skips an initial sanity check that function defintions will reliably generate working code')
+                    help='Skips an initial sanity check that the definition is self-consistent')
 parser.add_argument('-s', '--stats', action='store_true',
                     help='Save stats and write them to a file')
 parser.add_argument('--api-base',

--- a/marsha/base.py
+++ b/marsha/base.py
@@ -30,11 +30,16 @@ parser.add_argument('--exclude-sanity-check', action='store_true',
                     help='Skips an initial sanity check that function defintions will reliably generate working code')
 parser.add_argument('-s', '--stats', action='store_true',
                     help='Save stats and write them to a file')
+parser.add_argument('--api-base',
+                    help='Base URL of an OpenAI-compatible API to use for LLM requests, e.g. a local llama.cpp server. Overrides the OPENAI_BASE_URL environment variable and the config file')
 
 args = parser.parse_args()
 
 # Set up the shared LLM client
-set_client(create_client())
+client = create_client(args.api_base)
+set_client(client)
+if args.debug:
+    print(f'Using LLM endpoint: {client.base_url}')
 
 
 async def main():

--- a/marsha/config.py
+++ b/marsha/config.py
@@ -1,0 +1,60 @@
+import json
+import os
+import platform
+
+APP_NAME = 'marsha'
+CONFIG_FILENAME = 'config.json'
+DEFAULT_API_BASE = 'https://api.openai.com/v1'
+
+
+def get_config_dir():
+    system = platform.system()
+    if system == 'Windows':
+        base = os.environ.get('LOCALAPPDATA')
+        if base is None:
+            base = os.path.join(os.path.expanduser('~'), 'AppData', 'Local')
+        return os.path.join(base, APP_NAME)
+    if system == 'Darwin':
+        return os.path.join(os.path.expanduser('~'), 'Library', 'Application Support', APP_NAME)
+    base = os.environ.get('XDG_CONFIG_HOME')
+    if base is None:
+        base = os.path.join(os.path.expanduser('~'), '.config')
+    return os.path.join(base, APP_NAME)
+
+
+def get_config_path():
+    return os.path.join(get_config_dir(), CONFIG_FILENAME)
+
+
+def load_config_file():
+    config = {}
+    path = get_config_path()
+    if os.path.exists(path):
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                config = json.load(f)
+        except (OSError, ValueError) as e:
+            raise Exception(f'Failed to read config file at {path}: {e}')
+        if not isinstance(config, dict):
+            raise Exception(
+                f'Invalid config file at {path}: expected a JSON object')
+    return config
+
+
+def resolve_api_base(cli_value=None):
+    if cli_value:
+        return cli_value
+    env_value = os.getenv('OPENAI_BASE_URL')
+    if env_value:
+        return env_value
+    file_value = load_config_file().get('api_base')
+    if file_value:
+        return file_value
+    return DEFAULT_API_BASE
+
+
+def resolve_api_key():
+    env_value = os.getenv('OPENAI_SECRET_KEY') or os.getenv('OPENAI_API_KEY')
+    if env_value:
+        return env_value
+    return load_config_file().get('api_key')

--- a/marsha/config.py
+++ b/marsha/config.py
@@ -5,6 +5,10 @@ import platform
 APP_NAME = 'marsha'
 CONFIG_FILENAME = 'config.json'
 DEFAULT_API_BASE = 'https://api.openai.com/v1'
+DEFAULT_MODEL = 'gpt-5-mini'
+DEFAULT_STRONG_MODEL = 'gpt-5'
+
+_cli_model = None
 
 
 def get_config_dir():
@@ -41,6 +45,11 @@ def load_config_file():
     return config
 
 
+def set_cli_model(model):
+    global _cli_model
+    _cli_model = model
+
+
 def resolve_api_base(cli_value=None):
     if cli_value:
         return cli_value
@@ -58,3 +67,19 @@ def resolve_api_key():
     if env_value:
         return env_value
     return load_config_file().get('api_key')
+
+
+def resolve_model():
+    if _cli_model:
+        return _cli_model
+    file_value = load_config_file().get('model')
+    if file_value:
+        return file_value
+    return DEFAULT_MODEL
+
+
+def resolve_strong_model():
+    file_value = load_config_file().get('model_strong')
+    if file_value:
+        return file_value
+    return DEFAULT_STRONG_MODEL

--- a/marsha/llm.py
+++ b/marsha/llm.py
@@ -10,11 +10,12 @@ import sys
 
 from pylama.main import parse_options, check_paths, DEFAULT_FORMAT
 
+from marsha.config import resolve_model, resolve_strong_model
 from marsha.meta import MarshaMeta
 from marsha.parse import validate_first_stage_markdown, validate_second_stage_markdown, write_files_from_markdown, format_marsha_for_llm, extract_func_name
 from marsha.stats import stats
 from marsha.utils import read_file, autoformat_files, prettify_time_delta
-from marsha.mappers.chatgpt import ChatGPTMapper
+from marsha.mappers.chatgpt import ChatGPTMapper, uses_completion_tokens
 
 # PyInstaller creates a temp folder and stores path in _MEIPASS
 base_path = '.'
@@ -28,6 +29,12 @@ if shutil.which(python) is None:
 
 
 async def gpt_can_func_python(meta: MarshaMeta, n_results: int):
+    # Reasoning models need a larger budget for their chain of thought, so the
+    # one-token cap only applies to non-reasoning models
+    if uses_completion_tokens(resolve_model()):
+        answer = {'max_tokens': 1024, 'reasoning_effort': 'minimal'}
+    else:
+        answer = {'max_tokens': 1}
     gpt_can_func = ChatGPTMapper('''You are a senior software engineer reviewing an assignment to write a Python 3 function.
 The assignment is written in markdown format.
 It should include sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
@@ -36,7 +43,7 @@ The description must be precise enough to determine what to do.
 The examples must be complete enough to likely catch all edge cases.
 If the description and examples are broad enough that different engineers could reasonably create very different functions that supposedly meet the requirements but do different things, that is another reason to reject this assignment.
 Your answer is consumed by project management software, so only respond with Y for yes or N for no.
-''', max_tokens=1, n_results=n_results, stats_stage='first_stage')
+''', n_results=n_results, stats_stage='first_stage', **answer)
     marsha_for_code_llm = format_marsha_for_llm(meta)
     gpt_opinions = await gpt_can_func.run(marsha_for_code_llm)
     if any([True if opinion == 'N' else False for opinion in gpt_opinions]):
@@ -440,7 +447,7 @@ The desired response must look like the following:
 <fixed code>
 ```
 
-''', model='gpt-4', stats_stage='third_stage')
+''', model=resolve_strong_model(), stats_stage='third_stage')
         fixed_code = await gpt_fix.run(f'''{format_marsha_for_llm(meta)}
 
 {f"""## Do not test the following functions:

--- a/marsha/llm.py
+++ b/marsha/llm.py
@@ -38,10 +38,9 @@ async def gpt_can_func_python(meta: MarshaMeta, n_results: int):
     gpt_can_func = ChatGPTMapper('''You are a senior software engineer reviewing an assignment to write a Python 3 function.
 The assignment is written in markdown format.
 It should include sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
-You are assessing only whether the document is self-consistent: whether its description, inputs, outputs, and examples can all be true at the same time.
-Underspecification is not a reason to reject: like unspecified behavior in C, whatever the document leaves open is for the implementer to decide reasonably, and that is acceptable.
-The examples may be more specific than the description, choosing among the options the description leaves open; that is not a contradiction.
-Reject only when the document contradicts itself, eg the description says the function prints its result while the examples compare its return value to a string, two examples give different outputs for the same input, or an example violates a stated requirement.
+You are assessing only whether the document is self-consistent. Use this test: could at least one implementation exist that satisfies every part of the document (description, inputs, outputs, and all examples) at the same time? If such an implementation could exist, the document is self-consistent.
+Underspecification is not a reason to reject: like unspecified behavior in C, whatever the document leaves open is for the implementer to decide reasonably. If the description allows several outcomes (several valid orderings, several equivalent error messages, several formats) and the examples show one of them, an implementation that follows the examples satisfies the document, so that is self-consistent.
+Reject only when no implementation could satisfy the document as written, eg the description says the function prints its result while the examples compare its return value to a string, two examples give different outputs for the same input, or an example is malformed or violates a stated requirement.
 Your answer is consumed by project management software, so only respond with Y if the document is self-consistent, or N if it contradicts itself.
 ''', n_results=n_results, stats_stage='first_stage', **answer)
     marsha_for_code_llm = format_marsha_for_llm(meta)

--- a/marsha/llm.py
+++ b/marsha/llm.py
@@ -38,11 +38,11 @@ async def gpt_can_func_python(meta: MarshaMeta, n_results: int):
     gpt_can_func = ChatGPTMapper('''You are a senior software engineer reviewing an assignment to write a Python 3 function.
 The assignment is written in markdown format.
 It should include sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
-You are assessing if this document has enough context such that a junior software engineer with a couple of years of experience should be able to write the desired function and a test suite to verify it.
-The description must be precise enough to determine what to do.
-The examples must be complete enough to likely catch all edge cases.
-If the description and examples are broad enough that different engineers could reasonably create very different functions that supposedly meet the requirements but do different things, that is another reason to reject this assignment.
-Your answer is consumed by project management software, so only respond with Y for yes or N for no.
+You are assessing only whether the document is self-consistent: whether its description, inputs, outputs, and examples can all be true at the same time.
+Underspecification is not a reason to reject: like unspecified behavior in C, whatever the document leaves open is for the implementer to decide reasonably, and that is acceptable.
+The examples may be more specific than the description, choosing among the options the description leaves open; that is not a contradiction.
+Reject only when the document contradicts itself, eg the description says the function prints its result while the examples compare its return value to a string, two examples give different outputs for the same input, or an example violates a stated requirement.
+Your answer is consumed by project management software, so only respond with Y if the document is self-consistent, or N if it contradicts itself.
 ''', n_results=n_results, stats_stage='first_stage', **answer)
     marsha_for_code_llm = format_marsha_for_llm(meta)
     gpt_opinions = await gpt_can_func.run(marsha_for_code_llm)
@@ -54,11 +54,10 @@ Your answer is consumed by project management software, so only respond with Y f
 gpt_improve = ChatGPTMapper('''You are a senior software engineer reviewing an assignment to write a Python 3 function that a junior software engineer has written.
 The assignment is written in markdown format.
 It includes sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
-You have already decided this document is not written well enough such that another engineer can reliably write a working function that meets expectations, nor a test suite to verify proper functionality.
-The description must be precise enough to determine what to do.
-The examples must be complete enough to likely catch all edge cases.
-You are writing a few paragraphs gently explaining the deficiencies in the task definition they have written, not coming up with examples assuming what they might have wanted, since that isn't clear in the first place, just why what they have provided is not precise enough.
-In your response do not refer to the person at all or tell them what mistakes "they" have made. This is a blameless culture. The mistakes simply are, and that they made them isn't a problem, just that they should learn from them.
+You have already decided this document contradicts itself, so it cannot be implemented as written.
+You are writing a few paragraphs gently explaining the specific contradictions in the task definition, with concrete pointers to where each one appears (the description, particular examples, etc), so the author can resolve them.
+Do not ask for more examples or more precision in areas that are merely unspecified: unspecified behavior is acceptable and for the implementer to decide, like unspecified behavior in C.
+In your response do not refer to the person at all or tell them what mistakes "they" have made. This is a blameless culture. The contradictions simply are, and that is not a problem, just something to resolve.
 Do not include a "hello" or a "regards", etc, as your response is being attached to a code review system.
 ''', stats_stage='first_stage')
 

--- a/marsha/llm_client.py
+++ b/marsha/llm_client.py
@@ -1,0 +1,24 @@
+import os
+
+import openai
+
+_client = None
+
+
+def create_client():
+    return openai.AsyncOpenAI(
+        api_key=os.getenv('OPENAI_SECRET_KEY') or os.getenv('OPENAI_API_KEY'),
+        organization=os.getenv('OPENAI_ORG'),
+    )
+
+
+def get_client():
+    global _client
+    if _client is None:
+        _client = create_client()
+    return _client
+
+
+def set_client(client):
+    global _client
+    _client = client

--- a/marsha/llm_client.py
+++ b/marsha/llm_client.py
@@ -2,12 +2,15 @@ import os
 
 import openai
 
+from marsha.config import resolve_api_base, resolve_api_key
+
 _client = None
 
 
-def create_client():
+def create_client(api_base=None):
     return openai.AsyncOpenAI(
-        api_key=os.getenv('OPENAI_SECRET_KEY') or os.getenv('OPENAI_API_KEY'),
+        base_url=resolve_api_base(api_base),
+        api_key=resolve_api_key(),
         organization=os.getenv('OPENAI_ORG'),
     )
 

--- a/marsha/mappers/chatgpt.py
+++ b/marsha/mappers/chatgpt.py
@@ -2,6 +2,7 @@ import time
 
 import openai
 
+from marsha.config import resolve_model, resolve_strong_model
 from marsha.llm_client import get_client
 from marsha.mappers.base import BaseMapper
 from marsha.stats import stats
@@ -11,11 +12,20 @@ from marsha.utils import prettify_time_delta
 t0 = time.time()
 
 
-async def retry_chat_completion(query, model='gpt-3.5-turbo', max_tries=3, n_results=1):
+def uses_completion_tokens(model):
+    # Reasoning models reject max_tokens and require max_completion_tokens
+    return model.startswith('gpt-5') or model.startswith('o')
+
+
+async def retry_chat_completion(query, model=None, max_tries=3, n_results=1):
     client = get_client()
+    if model is None:
+        model = resolve_model()
     t1 = time.time()
     query['model'] = model
     query['n'] = n_results
+    if 'max_tokens' in query and uses_completion_tokens(model):
+        query['max_completion_tokens'] = query.pop('max_tokens')
     while True:
         try:
             out = await client.chat.completions.create(**query)
@@ -27,7 +37,7 @@ async def retry_chat_completion(query, model='gpt-3.5-turbo', max_tries=3, n_res
         except openai.BadRequestError as e:
             if getattr(e, 'code', None) == 'context_length_exceeded':
                 # Try to cover up this error by choosing the bigger, more expensive model
-                query['model'] = 'gpt-4'
+                query['model'] = resolve_strong_model()
             max_tries = max_tries - 1
             if max_tries == 0:
                 raise e
@@ -44,11 +54,12 @@ async def retry_chat_completion(query, model='gpt-3.5-turbo', max_tries=3, n_res
 class ChatGPTMapper(BaseMapper):
     """ChatGPT-based mapper class"""
 
-    def __init__(self, system, model='gpt-3.5-turbo', max_tokens=None, max_retries=3, n_results=1, stats_stage=None):
+    def __init__(self, system, model=None, max_tokens=None, reasoning_effort=None, max_retries=3, n_results=1, stats_stage=None):
         BaseMapper.__init__(self)
         self.system = system
         self.model = model
         self.max_tokens = max_tokens
+        self.reasoning_effort = reasoning_effort
         self.max_retries = max_retries
         self.n_results = n_results
         self.stats_stage = stats_stage
@@ -65,6 +76,8 @@ class ChatGPTMapper(BaseMapper):
         }
         if self.max_tokens is not None:
             query_obj['max_tokens'] = self.max_tokens
+        if self.reasoning_effort is not None:
+            query_obj['reasoning_effort'] = self.reasoning_effort
         res = await retry_chat_completion(query_obj, self.model, self.max_retries, self.n_results)
 
         if self.stats_stage is not None:

--- a/marsha/mappers/chatgpt.py
+++ b/marsha/mappers/chatgpt.py
@@ -1,6 +1,8 @@
-import openai
 import time
 
+import openai
+
+from marsha.llm_client import get_client
 from marsha.mappers.base import BaseMapper
 from marsha.stats import stats
 from marsha.utils import prettify_time_delta
@@ -10,18 +12,20 @@ t0 = time.time()
 
 
 async def retry_chat_completion(query, model='gpt-3.5-turbo', max_tries=3, n_results=1):
+    client = get_client()
     t1 = time.time()
     query['model'] = model
     query['n'] = n_results
     while True:
         try:
-            out = await openai.ChatCompletion.acreate(**query)
+            out = await client.chat.completions.create(**query)
             t2 = time.time()
+            total_tokens = out.usage.total_tokens if out.usage is not None else 9001
             print(
-                f'''Chat query took {prettify_time_delta(t2 - t1)}, started at {prettify_time_delta(t1 - t0)}, ms/chars = {(t2 - t1) * 1000 / out.get('usage', {}).get('total_tokens', 9001)}''')
+                f'''Chat query took {prettify_time_delta(t2 - t1)}, started at {prettify_time_delta(t1 - t0)}, ms/chars = {(t2 - t1) * 1000 / total_tokens}''')
             return out
-        except openai.error.InvalidRequestError as e:
-            if e.code == 'context_length_exceeded':
+        except openai.BadRequestError as e:
+            if getattr(e, 'code', None) == 'context_length_exceeded':
                 # Try to cover up this error by choosing the bigger, more expensive model
                 query['model'] = 'gpt-4'
             max_tries = max_tries - 1

--- a/marsha/requirements.txt
+++ b/marsha/requirements.txt
@@ -2,9 +2,10 @@ autopep8
 flake8
 mccabe
 mistletoe
-openai
+openai>=1.0
 pycodestyle
 pydocstyle
 pyflakes
 pyinstaller
 pylama
+setuptools<81

--- a/marsha/stats.py
+++ b/marsha/stats.py
@@ -1,19 +1,21 @@
-import functools
-
 from marsha.utils import write_file
 
-# OpenAI pricing model.
-# Format: (tokens, price). Price per 1024 tokens.
+# Price per 1024 tokens (input, output), matched by longest model name prefix
 PRICING_MODEL = {
-    'gpt35': {
-        'in': [(4096, 0.0015), (16384, 0.002)],
-        'out': [(4096, 0.002), (16384, 0.004)]
-    },
-    'gpt4': {
-        'in': [(8192, 0.03), (32768, 0.06)],
-        'out': [(8192, 0.06), (32768, 0.12)]
-    }
+    'gpt-5-mini': (0.000244140625, 0.001953125),
+    'gpt-5-nano': (0.000048828125, 0.000390625),
+    'gpt-5': (0.001220703125, 0.009765625),
+    'gpt-4': (0.03, 0.06),
+    'gpt-3.5': (0.0015, 0.002),
 }
+
+
+def price_for(model):
+    best = None
+    for prefix in PRICING_MODEL:
+        if model.startswith(prefix) and (best is None or len(prefix) > len(best)):
+            best = prefix
+    return PRICING_MODEL[best] if best else (0.0, 0.0)
 
 
 class ModelStats:
@@ -31,8 +33,20 @@ class StageStats:
         self.name = name
         self.total_time = total_time
         self.total_calls = total_calls
-        self.gpt35 = ModelStats('gpt-3.5-turbo', 0, 0, 0, 0, 0)
-        self.gpt4 = ModelStats('gpt-4', 0, 0, 0, 0, 0)
+        self.models = {}
+
+    def update(self, res: list):
+        self.total_calls += len(res)
+        for r in res:
+            ms = self.models.get(r.model)
+            if ms is None:
+                ms = self.models[r.model] = ModelStats(r.model, 0, 0, 0, 0, 0)
+            in_price, out_price = price_for(r.model)
+            ms.input_tokens += r.usage.prompt_tokens
+            ms.input_cost += r.usage.prompt_tokens * in_price / 1024
+            ms.output_tokens += r.usage.completion_tokens
+            ms.output_cost += r.usage.completion_tokens * out_price / 1024
+            ms.total_cost = ms.input_cost + ms.output_cost
 
 
 class MarshaStats:
@@ -45,44 +59,21 @@ class MarshaStats:
         self.second_stage = StageStats('second_stage', 0, 0)
         self.third_stage = StageStats('third_stage', 0, 0)
 
+    @property
+    def stages(self):
+        return [self.first_stage, self.second_stage, self.third_stage]
+
+    def stage_update(self, stage: str, res: list):
+        stage_stats = getattr(self, stage, None)
+        if isinstance(stage_stats, StageStats):
+            stage_stats.update(res)
+
     def aggregate(self, total_time, attempts):
         self.total_time = total_time
         self.attempts = attempts
-        self.total_calls = self.first_stage.total_calls + \
-            self.second_stage.total_calls + self.third_stage.total_calls
-        self.total_cost = self.first_stage.gpt35.total_cost + self.first_stage.gpt4.total_cost + self.second_stage.gpt35.total_cost + \
-            self.second_stage.gpt4.total_cost + \
-            self.third_stage.gpt35.total_cost + self.third_stage.gpt4.total_cost
-
-    def stage_update(self, stage: str, res: list):
-        rsetattr(self, f'{stage}.total_calls', rgetattr(
-            self, f'{stage}.total_calls') + len(res))
-        for r in res:
-            model = 'gpt4' if r.model.startswith('gpt-4') else 'gpt35'
-            input_tokens = r.usage.prompt_tokens
-            rsetattr(self, f'{stage}.{model}.input_tokens', rgetattr(
-                self, f'{stage}.{model}.input_tokens') + input_tokens)
-            pricing = PRICING_MODEL[model]
-            # Calculate input cost based on context length
-            if (input_tokens <= pricing['in'][0][0]):
-                rsetattr(self, f'{stage}.{model}.input_cost', rgetattr(
-                    self, f'{stage}.{model}.input_cost') + input_tokens * pricing['in'][0][1] / 1024)
-            elif (input_tokens <= pricing['in'][1][0]):
-                rsetattr(self, f'{stage}.{model}.input_cost', rgetattr(
-                    self, f'{stage}.{model}.input_cost') + input_tokens * pricing['in'][1][1] / 1024)
-            output_tokens = r.usage.completion_tokens
-            rsetattr(self, f'{stage}.{model}.output_tokens', rgetattr(
-                self, f'{stage}.{model}.output_tokens') + output_tokens)
-            # Calculate output cost based on context length
-            if (output_tokens <= pricing['out'][0][0]):
-                rsetattr(self, f'{stage}.{model}.output_cost', rgetattr(
-                    self, f'{stage}.{model}.output_cost') + output_tokens * pricing['out'][0][1] / 1024)
-            elif (output_tokens <= pricing['out'][1][0]):
-                rsetattr(self, f'{stage}.{model}.output_cost', rgetattr(
-                    self, f'{stage}.{model}.output_cost') + output_tokens * pricing['out'][1][1] / 1024)
-            # Calculate total cost
-            rsetattr(self, f'{stage}.{model}.total_cost', rgetattr(self, f'{stage}.{model}.total_cost') +
-                     rgetattr(self, f'{stage}.{model}.input_cost') + rgetattr(self, f'{stage}.{model}.output_cost'))
+        self.total_calls = sum(stage.total_calls for stage in self.stages)
+        self.total_cost = sum(
+            ms.total_cost for stage in self.stages for ms in stage.models.values())
 
     def to_file(self, filename: str = 'stats.md'):
         write_file(filename, content=self.__str__())
@@ -91,45 +82,29 @@ class MarshaStats:
         return self.__str__()
 
     def __str__(self):
-        return f'''# Stats
-
-## First stage
-Total time: {self.first_stage.total_time}
-Total calls: {self.first_stage.total_calls}
-Total cost: {self.first_stage.gpt35.total_cost + self.first_stage.gpt4.total_cost}
-
-## Second stage
-Total time: {self.second_stage.total_time}
-Total calls: {self.second_stage.total_calls}
-Total cost: {self.second_stage.gpt35.total_cost + self.second_stage.gpt4.total_cost}
-
-## Third stage
-Total time: {self.third_stage.total_time}
-Total calls: {self.third_stage.total_calls}
-Total cost: {self.third_stage.gpt35.total_cost + self.third_stage.gpt4.total_cost}
-
-## Total
-Total time: {self.total_time}
-Total calls: {self.total_calls}
-Attempts: {self.attempts}
-Total cost: {self.total_cost}
-'''
-
-
-"""
-Source: https://stackoverflow.com/questions/31174295/getattr-and-setattr-on-nested-subobjects-chained-properties
-"""
-
-
-def rsetattr(obj, attr, val):
-    pre, _, post = attr.rpartition('.')
-    return setattr(rgetattr(obj, pre) if pre else obj, post, val)
-
-
-def rgetattr(obj, attr, *args):
-    def _getattr(obj, attr):
-        return getattr(obj, attr, *args)
-    return functools.reduce(_getattr, [obj] + attr.split('.'))
+        stage_titles = {
+            'first_stage': 'First',
+            'second_stage': 'Second',
+            'third_stage': 'Third',
+        }
+        lines = ['# Stats', '']
+        for stage in self.stages:
+            total_cost = sum(ms.total_cost for ms in stage.models.values())
+            lines.append(f'## {stage_titles[stage.name]} stage')
+            lines.append(f'Total time: {stage.total_time}')
+            lines.append(f'Total calls: {stage.total_calls}')
+            lines.append(f'Total cost: {total_cost}')
+            for ms in stage.models.values():
+                lines.append(
+                    f'  {ms.name}: {ms.input_tokens} input tokens, '
+                    f'{ms.output_tokens} output tokens, cost {ms.total_cost}')
+            lines.append('')
+        lines.append('## Total')
+        lines.append(f'Total time: {self.total_time}')
+        lines.append(f'Total calls: {self.total_calls}')
+        lines.append(f'Attempts: {self.attempts}')
+        lines.append(f'Total cost: {self.total_cost}')
+        return '\n'.join(lines)
 
 
 stats = MarshaStats()

--- a/setup.py
+++ b/setup.py
@@ -14,12 +14,13 @@ setup(
         'flake8',
         'mccabe',
         'mistletoe',
-        'openai',
+        'openai>=1.0',
         'pycodestyle',
         'pydocstyle',
         'pyflakes',
         'pyinstaller',
-        'pylama'
+        'pylama',
+        'setuptools<81'
     ],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
## Summary

Completes #165 (Llama.cpp support) by making Marsha's LLM endpoint configurable, rather than embedding llama.cpp directly (the approach of the abandoned draft #164): llama.cpp ships an OpenAI-compatible API server, so Marsha just needs to be able to point at an alternative URL. Since the code's OpenAI client was from 2023 and no longer installable/working, that migration happens in the first commit.

## Changes

1. **Migrate from the legacy openai client to `openai>=1`** — `openai.ChatCompletion.acreate` no longer exists in current releases, so fresh installs were broken at import. Uses `AsyncOpenAI` (the `acreate` equivalent) via a shared client holder (`marsha/llm_client.py`), maps `InvalidRequestError` to `BadRequestError`, pins `openai>=1.0` and `setuptools<81` (pylama still imports `pkg_resources`).
2. **Configurable endpoint** — new `--api-base` flag and a JSON config file (`api_base`, `api_key`) loaded from the standard per-OS location: `~/.config/marsha/config.json` (honors `XDG_CONFIG_HOME`) on Linux, `~/Library/Application Support/marsha/config.json` on macOS, `%LOCALAPPDATA%\marsha\config.json` on Windows. Precedence: `--api-base` > `OPENAI_BASE_URL` > config file > OpenAI default.
3. **Modern, configurable models** — default generation model is `gpt-5-mini`, with `gpt-5` for the test-fix stage and context-overflow escalation; new `model`/`model_strong` config keys and `--model` flag. Reasoning models reject `max_tokens`, so it is translated to `max_completion_tokens` for them, and the sanity check uses `reasoning_effort=minimal` with a larger budget. Stats now track cost per actual response model (and the old cumulative-cost double counting is fixed).
4. **Sanity check retargeted at self-consistency** — underspecified definitions are acceptable (like unspecified behavior in C: the implementer decides); the check rejects only self-contradictory definitions (eg a description saying the function prints while examples compare a returned string). `examples/general-purpose/now.mrsh` had exactly that contradiction and is fixed. Warnings for underspecified-but-consistent definitions are tracked separately in #173.

## Verification

- **Live OpenAI API**: sanity check (both accept and reject paths), full three-stage pipelines on `now.mrsh` and `fibonacci.mrsh` (including the `gpt-5` test-fix path, which was exercised when a first test attempt failed), `--model gpt-5-nano` override, and per-model cost reporting. Generated code passes its generated test suites.
- **llama.cpp**: end-to-end round-trip through Marsha's mapper code path against a live llama.cpp server (`http://trelast:8080/v1`), plus full-pipeline runs against a mock OpenAI-compatible server covering config-file loading, CLI/env override precedence, defaults, and malformed config handling.
- CI lint (autopep8 + flake8) passes.

Closes #165