### PR TITLE
Fail the time suite below 90% success; remove roadmap (now issues)

### DIFF
--- a/.time.py
+++ b/.time.py
@@ -4,6 +4,7 @@ import argparse
 import math
 import os
 import subprocess
+import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -141,6 +142,11 @@ print(results)
 res_file = open('results.md', 'w')
 res_file.write(results)
 res_file.close()
+
+# Fail the suite if fewer than 90% of the runs succeeded
+if sum(successes) * 100 < total_runs * 90:
+    print(f'Suite FAILED: only {sum(successes)} of {total_runs} runs succeeded (below the 90% threshold)')
+    sys.exit(1)
 
 if args.stats:
     with open('agg_stats.md', 'r') as f:

--- a/README.md
+++ b/README.md
@@ -215,20 +215,3 @@ options:
 * `-j` and `-t` let you choose if the param(s) provided will be parsed as JSON or kept as plain text. By default it will opportunistically parse the arguments but if it fails will keep it as text
 * `-i`, `-f`, and `-o` let you choose how input and output is managed. By default inputs are the `params` arguments and the output is to `stdout`, but you can use `-i` to then ignore all `params` and treat `stdin` as the singular input param for your function. Similarly `-f` will do the same, but for the file you specify, and `-o` will write the result to a file you specify instead of to `stdout`.
 * `-s` Is a flag to instead run a simple REST server. Using this flag causes it to ignore all other flags. The various function names become `/func_name` endpoints that you can POST to and get a response body back. If you set the `Content-Type` header to `application/json` the input and output will be JSON, if not it will be plain text. If your function takes mutliple arguments, it *must* be called in JSON mode with the arguments each being an element of a top-level array.
-
-## Roadmap
-
-- Improve average accuracy for our test bed above 90%
-- Support for visualizations and data storage (geek mode: handle side-effect logic better in general)
-- Syntax highlighting (vim, vscode, etc)
-- Support for different types of LLM
-- Bootstrap the Marsha compiler with a Marsha program
-- More target languages other than Python
-- A module system
-- Edits to Marsha mutating existing Python code instead of regenerating
-- "Decompiler" from source code into Marsha syntax
-- "Debugger" meta mode to take existing Marsha definition and an example of an unexpected failure and recommend what to update with the Marsha definition.
-- Optmization "levels" (spend more time on more iterations with the LLM improving performance, security, etc)
-- Marsha GUI mode: visual editor baked into the compiler (eventually with the decompiler/debugger/etc features), and able to generate a GUI wrapper for generated code, enabling end-to-end non-terminal usage
-- Better support for a mixed environment (Marsha functions can be used by Python, but how to get Marsha to use hand-written Python functions)
-- Better "web scraping" behavior (LLM likes to assume the internet still looks like it did in November 2021, but HTML structure has often changed for the largest websites; automatically correcting that assumption would be nice)


### PR DESCRIPTION
The old Roadmap section of the README is now tracked as issues #180-#191 (the two completed items - 90% accuracy and multi-LLM support - were dropped without issues).

The time suite previously always exited 0 and only *reported* the success count. It now fails (exit 1) when fewer than 90% of runs succeed: 27/30 for the OpenAI job, 14/15 for the Claude job.