### PR TITLE
Sanity check: structured verdict with warnings on stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The Marsha syntax is meant to be:
 
 Marsha is compiled by an LLM into tested software that meets the requirements described, but implementation details can vary greatly across runs much like if different developers implemented it for you. There is typically more than one way to write software that fulfills a set of requirements. However, the compiler is best-effort and sometimes it will fail to generate the described program. We aim for 80%+ accuracy on our [examples](./examples/). In general, the more detailed the description and the more examples are provided the more likely the output will work.
 
+Before generating any code, the compiler runs a sanity check that the definition is self-consistent, and prints warnings about significant ambiguities to `stderr` that could result in differently-behaving code between generation runs. Warnings are always shown while compiling, like a conventional compiler's; `--no-warn` suppresses them, but the check itself still runs and still fails the compile when the definition contradicts itself.
+
 In order to use the compiler, Marsha needs to know which LLM to send requests to. By default it uses the OpenAI API, which requires the following environment variables to be set:
 
 * `OPENAI_ORG`
@@ -138,8 +140,8 @@ There are also a few flags on how to use Marsha:
 ```sh
 $ marsha --help
 usage: marsha [-h] [-d] [-q] [-a ATTEMPTS] [-n N_PARALLEL_EXECUTIONS]
-              [--exclude-main-helper] [--exclude-sanity-check] [-s]
-              [--api-base API_BASE] [--model MODEL]
+              [--exclude-main-helper] [--exclude-sanity-check] [--no-warn]
+              [-s] [--api-base API_BASE] [--model MODEL]
               [--provider {openai,anthropic}]
               source
 
@@ -160,6 +162,8 @@ options:
   --exclude-sanity-check
                         Skips an initial sanity check that the definition is
                         self-consistent
+  --no-warn             Do not display warnings about ambiguous areas of the
+                        definition from the sanity check
   -s, --stats           Save stats and write them to a file
   --api-base API_BASE   Base URL of an OpenAI-compatible API to use for LLM
                         requests, e.g. a local llama.cpp server. Overrides the
@@ -178,6 +182,7 @@ options:
 * `-n` The number of parallel LLM threads of "thought" to pursue per attempt. This defaults to 3. When a path succeeds, all of the other paths are cancelled.
 * `-s` Save the stats that are printed by default to a file, instead. Probably not useful if you're not working on Marsha itself.
 * `--exclude-main-helper` Turns off the automatically generated code to make using your compiled Marsha code from the CLI easier, which is included by default.
+* `--no-warn` Suppresses the warnings the sanity check prints about significant ambiguities in the definition. The check itself still runs, and still fails the compile when the definition contradicts itself.
 * `--api-base` Overrides the LLM endpoint with the base URL of any OpenAI-compatible API (eg `http://localhost:8080/v1` for a llama.cpp server). Takes precedence over the `OPENAI_BASE_URL` environment variable and the config file.
 * `--model` Overrides the model used for code generation (default `gpt-5-mini`, `claude-sonnet-5` with the anthropic provider), eg to use a different model or the name of a locally served model.
 * `--provider` Selects the LLM provider: `openai` (default; any OpenAI-compatible API) or `anthropic` (Claude, keyed by `CLAUDE_API_KEY` or `ANTHROPIC_API_KEY`).

--- a/marsha/base.py
+++ b/marsha/base.py
@@ -29,6 +29,8 @@ parser.add_argument('--exclude-main-helper', action='store_true',
                     help='Skips addition of helper code for running as a script')
 parser.add_argument('--exclude-sanity-check', action='store_true',
                     help='Skips an initial sanity check that the definition is self-consistent')
+parser.add_argument('--no-warn', action='store_true',
+                    help='Do not display warnings about ambiguous areas of the definition from the sanity check')
 parser.add_argument('-s', '--stats', action='store_true',
                     help='Save stats and write them to a file')
 parser.add_argument('--api-base',

--- a/marsha/llm.py
+++ b/marsha/llm.py
@@ -1,5 +1,6 @@
 import asyncio
 from asyncio.subprocess import Process
+import json
 import os
 import platform
 import time
@@ -14,6 +15,7 @@ from marsha.config import resolve_model, resolve_provider, resolve_strong_model
 from marsha.meta import MarshaMeta
 from marsha.parse import validate_first_stage_markdown, validate_second_stage_markdown, write_files_from_markdown, format_marsha_for_llm, extract_func_name
 from marsha.stats import stats
+from marsha.term import print_diagnostic
 from marsha.utils import read_file, autoformat_files, prettify_time_delta
 from marsha.mappers import get_mapper
 from marsha.mappers.chatgpt import uses_completion_tokens
@@ -24,45 +26,73 @@ if shutil.which(python) is None:
     raise Exception('Python not found')
 
 
-async def gpt_can_func_python(meta: MarshaMeta, n_results: int):
-    # Reasoning models need a larger budget for their chain of thought, so the
-    # one-token cap only applies to non-reasoning models
-    if resolve_provider() == 'openai' and uses_completion_tokens(resolve_model()):
-        answer = {'max_tokens': 1024, 'reasoning_effort': 'minimal'}
-    else:
-        answer = {'max_tokens': 1}
-    gpt_can_func = get_mapper('''You are a senior software engineer reviewing an assignment to write a Python 3 function.
+SPEC_CHECK_PROMPT = '''You are a senior software engineer reviewing an assignment to write a Python 3 function.
 The assignment is written in markdown format.
 It should include sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
-You are assessing only whether the document is self-consistent. Use this test: could at least one implementation exist that satisfies every part of the document (description, inputs, outputs, and all examples) at the same time? If such an implementation could exist, the document is self-consistent.
-Underspecification is not a reason to reject: like unspecified behavior in C, whatever the document leaves open is for the implementer to decide reasonably. If the description allows several outcomes (several valid orderings, several equivalent error messages, several formats) and the examples show one of them, an implementation that follows the examples satisfies the document, so that is self-consistent.
-Reject only when no implementation could satisfy the document as written, eg the description says the function prints its result while the examples compare its return value to a string, two examples give different outputs for the same input, or an example is malformed or violates a stated requirement.
-Your answer is consumed by project management software, so only respond with Y if the document is self-consistent, or N if it contradicts itself.
-''', n_results=n_results, stats_stage='first_stage', **answer)
+
+First, decide whether the document is compilable. Use this test: could at least one implementation exist that satisfies every part of the document (description, inputs, outputs, and all examples) at the same time? If such an implementation could exist, the document is compilable.
+Underspecification is not a reason the document is not compilable: like unspecified behavior in C, whatever the document leaves open is for the implementer to decide reasonably. If the description allows several outcomes (several valid orderings, several equivalent error messages, several formats) and the examples show one of them, an implementation that follows the examples satisfies the document, so it is compilable.
+One section adding more detail than another is not a contradiction: sections only conflict when they state opposing views on what the code should be doing.
+The document is not compilable only when no implementation could satisfy it as written, eg the description says the function prints its result while the examples compare its return value to a string, two examples give different outputs for the same input, or an example is malformed or violates a stated requirement.
+
+Second, list warnings for significant ambiguities. A warning is for an underspecified or ambiguous area that could result in differently-behaving code between independent generation runs, eg a missing exception type or message, missing edge cases, an ambiguous output precision or format, or non-deterministic behavior that would make the generated code flaky to test.
+Be careful not to wear out the user with useless warnings: only warn when the ambiguity is significant enough that two reasonable implementers could plausibly produce different behavior. Do not warn about style, and do not ask for more examples or more precision in areas that are merely unspecified but unlikely to change the behavior.
+
+Respond with a single JSON object and nothing else, in exactly this shape:
+{"compilable": true, "warnings": ["...", "..."]}
+When the document is not compilable, include a third key, an "errors" array with one or more entries:
+{"compilable": false, "warnings": ["..."], "errors": ["...", "..."]}
+Each warning and each error is a markdown-formatted string that cites the relevant portion of the document using inline quotes of the document's own words. Each error must quote the sections that conflict with each other and explain why no implementation could satisfy both.
+Do not wrap the JSON object in code fences.
+'''
+
+
+def parse_spec_check(text):
+    """Parse the structured spec check response; raise on anything malformed"""
+    t = text.strip()
+    if t.startswith('```'):
+        t = t.split('\n', 1)[1] if '\n' in t else ''
+        if t.rstrip().endswith('```'):
+            t = t.rstrip()[:-3]
+    try:
+        obj = json.loads(t)
+    except json.JSONDecodeError:
+        start, end = t.find('{'), t.rfind('}')
+        if start == -1 or end <= start:
+            raise Exception(
+                f'No JSON object in spec check response: {text[:200]}')
+        obj = json.loads(t[start:end + 1])
+    if not isinstance(obj, dict) or not isinstance(obj.get('compilable'), bool):
+        raise Exception(f'Invalid spec check response: {text[:200]}')
+    warnings = obj.get('warnings', [])
+    errors = obj.get('errors', [])
+    if not isinstance(warnings, list) or not all(isinstance(w, str) for w in warnings):
+        raise Exception(f'Invalid spec check response: {text[:200]}')
+    if not isinstance(errors, list) or not all(isinstance(e, str) for e in errors):
+        raise Exception(f'Invalid spec check response: {text[:200]}')
+    if not obj['compilable'] and len(errors) == 0:
+        raise Exception(f'Not compilable without errors: {text[:200]}')
+    return {'compilable': obj['compilable'], 'warnings': warnings, 'errors': errors}
+
+
+async def gpt_check_spec(meta: MarshaMeta, retries: int = 2):
+    # Reasoning models need a larger budget for their chain of thought
+    if resolve_provider() == 'openai' and uses_completion_tokens(resolve_model()):
+        answer = {'max_tokens': 8192, 'reasoning_effort': 'minimal'}
+    elif resolve_provider() == 'anthropic':
+        answer = {'max_tokens': 4096}
+    else:
+        # Local OpenAI-compatible servers: leave the output budget to the server
+        answer = {}
+    gpt_check = get_mapper(SPEC_CHECK_PROMPT, n_results=1,
+                           stats_stage='first_stage', **answer)
     marsha_for_code_llm = format_marsha_for_llm(meta)
-    gpt_opinions = await gpt_can_func.run(marsha_for_code_llm)
-    if any([True if opinion == 'N' else False for opinion in gpt_opinions]):
-        return False
-    return True
-
-
-def get_gpt_improve():
-    # Constructed per call so the LLM provider is resolved from the parsed CLI args
-    return get_mapper('''You are a senior software engineer reviewing an assignment to write a Python 3 function that a junior software engineer has written.
-The assignment is written in markdown format.
-It includes sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
-You have already decided this document contradicts itself, so it cannot be implemented as written.
-You are writing a few paragraphs gently explaining the specific contradictions in the task definition, with concrete pointers to where each one appears (the description, particular examples, etc), so the author can resolve them.
-Do not ask for more examples or more precision in areas that are merely unspecified: unspecified behavior is acceptable and for the implementer to decide, like unspecified behavior in C.
-In your response do not refer to the person at all or tell them what mistakes "they" have made. This is a blameless culture. The contradictions simply are, and that is not a problem, just something to resolve.
-Do not include a "hello" or a "regards", etc, as your response is being attached to a code review system.
-''', stats_stage='first_stage')
-
-
-async def gpt_improve_func(meta: MarshaMeta):
-    marsha_for_code_llm = format_marsha_for_llm(meta)
-    improvements = await get_gpt_improve().run(marsha_for_code_llm)
-    print(improvements)
+    try:
+        return parse_spec_check(await gpt_check.run(marsha_for_code_llm))
+    except Exception:
+        if retries > 0:
+            return await gpt_check_spec(meta, retries - 1)
+        raise
 
 
 async def gpt_func_to_python(meta: MarshaMeta, n_results: int, retries: int = 3, debug: bool = False):
@@ -508,8 +538,13 @@ async def generate_python_code(args, meta: MarshaMeta, n_results: int, debug: bo
     mds = None
     try:
         if not args.exclude_sanity_check:
-            if not await gpt_can_func_python(meta, n_results):
-                await gpt_improve_func(meta)
+            check = await gpt_check_spec(meta)
+            if not args.no_warn:
+                for warning in check['warnings']:
+                    print_diagnostic('warning', warning)
+            for error in check['errors']:
+                print_diagnostic('error', error)
+            if not check['compilable']:
                 sys.exit(1)
         mds = await gpt_func_to_python(meta, n_results, debug=debug)
     except Exception as e:

--- a/marsha/term.py
+++ b/marsha/term.py
@@ -14,6 +14,11 @@ def _console():
 
 
 def print_diagnostic(kind, text):
-    """Print a warning or error to stderr; rich renders the markdown and omits color when not attached to a terminal"""
+    """Print a warning or error to stderr. Rich renders the markdown (with color only when attached
+    to a terminal); the trailing whitespace its list renderer leaves on each line is trimmed."""
     color = 'yellow' if kind == 'warning' else 'red'
-    _console().print(f'[bold {color}]{kind}:[/]', Markdown(text))
+    console = _console()
+    with console.capture() as capture:
+        console.print(f'[bold {color}]{kind}:[/]', Markdown(text))
+    for line in capture.get().splitlines():
+        print(line.rstrip(), file=sys.stderr)

--- a/marsha/term.py
+++ b/marsha/term.py
@@ -1,4 +1,3 @@
-import re
 import sys
 
 from rich.console import Console
@@ -14,23 +13,7 @@ def _console():
     return _stderr_console
 
 
-def strip_markdown(text):
-    text = re.sub(r'(?m)^\s*>\s?', '', text)
-    text = re.sub(r'(?m)^\s{0,3}#{1,6}\s+', '', text)
-    text = re.sub(r'`([^`]*)`', r'\1', text)
-    text = re.sub(r'\*\*(.+?)\*\*', r'\1', text)
-    text = re.sub(r'__(.+?)__', r'\1', text)
-    text = re.sub(r'(?m)^\s*[-*+]\s+', '', text)
-    text = re.sub(r'(?m)^\s*\d+\.\s+', '', text)
-    text = re.sub(r'\*([^*\n]+)\*', r'\1', text)
-    return text.strip()
-
-
 def print_diagnostic(kind, text):
-    """Print a warning or error to stderr, rendering markdown when attached to a terminal"""
-    console = _console()
-    if console.is_terminal:
-        color = 'yellow' if kind == 'warning' else 'red'
-        console.print(f'[bold {color}]{kind}:[/]', Markdown(text))
-    else:
-        print(f'{kind}: {strip_markdown(text)}', file=sys.stderr)
+    """Print a warning or error to stderr; rich renders the markdown and omits color when not attached to a terminal"""
+    color = 'yellow' if kind == 'warning' else 'red'
+    _console().print(f'[bold {color}]{kind}:[/]', Markdown(text))

--- a/marsha/term.py
+++ b/marsha/term.py
@@ -1,0 +1,36 @@
+import re
+import sys
+
+from rich.console import Console
+from rich.markdown import Markdown
+
+_stderr_console = None
+
+
+def _console():
+    global _stderr_console
+    if _stderr_console is None:
+        _stderr_console = Console(file=sys.stderr, soft_wrap=True)
+    return _stderr_console
+
+
+def strip_markdown(text):
+    text = re.sub(r'(?m)^\s*>\s?', '', text)
+    text = re.sub(r'(?m)^\s{0,3}#{1,6}\s+', '', text)
+    text = re.sub(r'`([^`]*)`', r'\1', text)
+    text = re.sub(r'\*\*(.+?)\*\*', r'\1', text)
+    text = re.sub(r'__(.+?)__', r'\1', text)
+    text = re.sub(r'(?m)^\s*[-*+]\s+', '', text)
+    text = re.sub(r'(?m)^\s*\d+\.\s+', '', text)
+    text = re.sub(r'\*([^*\n]+)\*', r'\1', text)
+    return text.strip()
+
+
+def print_diagnostic(kind, text):
+    """Print a warning or error to stderr, rendering markdown when attached to a terminal"""
+    console = _console()
+    if console.is_terminal:
+        color = 'yellow' if kind == 'warning' else 'red'
+        console.print(f'[bold {color}]{kind}:[/]', Markdown(text))
+    else:
+        print(f'{kind}: {strip_markdown(text)}', file=sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "pydocstyle",
     "pyflakes",
     "pylama",
+    "rich",
     "setuptools<81",
 ]
 classifiers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ pycodestyle
 pydocstyle
 pyflakes
 pylama
+rich
 setuptools<81


### PR DESCRIPTION
Closes #173.

The sanity check is now a single structured call that returns a JSON object with a `compilable` boolean and a `warnings` array (plus an `errors` array when not compilable), replacing the old Y/N verdict and the separate prose-explanation call.

Design decisions implemented:
- **Warnings on by default**, `--no-warn` suppresses them (the check itself still runs and still fails self-contradictory definitions).
- Warnings are **always printed to `stderr`** while compiling, like a conventional compiler. Each is markdown-formatted and cites the relevant portion of the `.mrsh` file with inline quotes.
- **Pretty printing** is delegated entirely to `rich`: markdown is rendered with a yellow `warning:` / red `error:` label, and rich omits all color/ANSI output when stderr is not attached to a terminal, so piped/CI output stays clean.
- The prompt tells the model to warn only about **significant ambiguities that could result in differently-behaving code between generation runs**, and to avoid wearing the user out with useless warnings.
- `errors` entries cite the sections that conflict with each other, with the prompt emphasizing that one section adding more detail than another is not a contradiction — only opposing views on what the code should be doing is.

Also adds `rich` as a dependency (terminal markdown rendering).

Verified locally (OpenAI + Claude):
- `fibonacci.mrsh`: compiles; 2-3 calibrated warnings on stderr (exception type for fib(0), negative-input behavior, output type).
- Contradictory fixture (description says "prints... does not return a value" vs signature `string` + examples showing return values): 2 errors citing the conflicting sections, exit 1, no code generated.
- `--no-warn`: zero warnings on stderr, compiles normally.
- Non-TTY output verified ANSI-free.