### PR TITLE
Refactor: extract target-language concerns into a LanguageBackend abstraction

### DIFF
--- a/.github/workflows/install.yaml
+++ b/.github/workflows/install.yaml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.14
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Install uv
         run: python -m pip install uv
       - name: Install launcher
@@ -24,10 +24,10 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.10
+      - name: Set up Python 3.14
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Install uv
         run: python -m pip install uv
       - name: Install launcher

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,10 +11,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.client_payload.ref }}
-      - name: Set up Python 3.10
+      - name: Set up Python 3.14
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Install uv
         run: python -m pip install uv
       - name: Lint project

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,10 +11,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.client_payload.ref }}
-      - name: Set up Python 3.10
+      - name: Set up Python 3.14
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Install uv
         run: python -m pip install uv
       - name: Run unit tests

--- a/.github/workflows/time.yaml
+++ b/.github/workflows/time.yaml
@@ -35,10 +35,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.client_payload.ref }}
-      - name: Set up Python 3.10
+      - name: Set up Python 3.14
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Install uv
@@ -71,10 +71,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.client_payload.ref }}
-      - name: Set up Python 3.10
+      - name: Set up Python 3.14
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Install uv

--- a/.github/workflows/windows_run.yaml
+++ b/.github/workflows/windows_run.yaml
@@ -24,10 +24,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.client_payload.ref }}
-      - name: Set up Python 3.10
+      - name: Set up Python 3.14
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.14"
       - name: Display Python version
         run: python -c "import sys; print(sys.version)"
       - name: Output Inputs

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ Before generating any code, the compiler runs a sanity check that the definition
 
 The compiler then generates a test suite for the definition — the *oracle* — anchored to the description and examples in the `.mrsh` file, and only then generates the implementation to satisfy it. The implementation is written against this fixed oracle rather than the two being generated independently and reconciled afterwards. When a generated implementation fails the oracle, the compiler diagnoses whether the fault lies in the implementation or in a test: a faulty implementation is fixed directly, while a test that over-specifies or contradicts the definition is corrected through a separate, spec-anchored pass that must justify every change against the definition and will not weaken a test that is actually correct. The implementation is never allowed to edit the tests, and the tests are only ever edited by that spec-anchored path, so a correct test is never bent to match a buggy implementation.
 
+The TDD methodology above (sanity check, oracle-first generation, diagnose→fix routing, persona review loops) is target-language-agnostic: the language-specific steps — prompts, artifact naming and layout, output validation, linting, formatting, test execution, and the runnable-CLI step — are delegated to a **language backend** in [`marsha/backends/`](./marsha/backends/), selected with `--target`. Only the Python backend is wired today; the registry and dispatch are ready for additional targets.
+
 An optional `--optimize <level>` flag spends additional LLM iterations refining the result, one inner loop per phase. A higher level runs more review iterations: the test suite is double-checked for coverage and fidelity against the definition (every stated behavior is tested and nothing is invented), the implementation is iterated for performance, safety, and code quality — with each change re-run against the oracle and reverted if it regresses — and any test correction is re-validated against the definition before it is applied. The default level is 0, which disables these loops and changes neither behavior nor cost.
 
 Each review loop is driven by a panel of named review **personas**. In every iteration the loop's reviewers run independently and in parallel, each reporting `MAJOR` / `MINOR` / `NIT` findings; a per-phase implementor (the *editor*) then addresses those findings and returns a reasoning preamble plus the revised artifact. The built-in personas live in [`marsha/personas/`](./marsha/personas/) — one file per reviewer plus one editor per phase. The reviewer set for each loop is selectable with:
@@ -151,8 +153,8 @@ There are also a few flags on how to use Marsha:
 
 ```sh
 $ marsha --help
-usage: marsha [-h] [-d] [--trace] [--trace-full] [-q] [-a ATTEMPTS]
-              [-n N_PARALLEL_EXECUTIONS] [--exclude-main-helper]
+usage: marsha [-h] [-t TARGET] [-d] [--trace] [--trace-full] [-q]
+              [-a ATTEMPTS] [-n N_PARALLEL_EXECUTIONS] [--exclude-main-helper]
               [--exclude-sanity-check] [--no-warn] [--optimize OPTIMIZE]
               [--test-personas TEST_PERSONAS] [--impl-personas IMPL_PERSONAS]
               [--fix-personas FIX_PERSONAS]
@@ -169,6 +171,9 @@ positional arguments:
 
 options:
   -h, --help            show this help message and exit
+  -t, --target TARGET   Target language for the generated code, by backend id
+                        or alias (default: python). Only `python` is wired
+                        today; the registry is ready for more.
   -d, --debug           Turn on debug logging
   --trace               Also write a live, timestamped progress trace to
                         stderr (each phase and every LLM request, with its
@@ -249,6 +254,7 @@ options:
 * `--context-window` Overrides the context window (in tokens) used to size review/editor prompts. It is auto-detected from the service when possible (eg a llama.cpp server's `n_ctx`), else a documented default is used; set it if your backend mis-reports its window.
 * `--context-cap` The fraction of the context window a single prompt may occupy before its findings are compacted (default `0.5`).
 * `--provider` Selects the LLM provider: `openai` (default; any OpenAI-compatible API) or `anthropic` (Claude, keyed by `CLAUDE_API_KEY` or `ANTHROPIC_API_KEY`).
+* `--target` Selects the target language for the generated code, by backend id or alias (`python`, default). The compiler's language-specific steps — prompts, artifact layout, validation, linting, formatting, test execution, and the runnable-CLI helper — are delegated to a language backend; only `python` is wired today, and the registry is ready for more.
 
 ## Using compiled Marsha code
 

--- a/marsha/backends/__init__.py
+++ b/marsha/backends/__init__.py
@@ -1,0 +1,63 @@
+"""Target-language backends and their registry.
+
+The core keeps all orchestration; it delegates the language-specific leaves to the
+backend bound for the run. `select()` binds one from the CLI's --target (by id or
+alias); `current()` is what the core calls at each leaf. Only `python` is wired in
+this change; the registry + dispatch are ready for `rust` (#183) and later targets.
+"""
+
+from marsha.backends.base import LanguageBackend
+from marsha.backends.python import PythonBackend
+
+__all__ = ['LanguageBackend', 'PythonBackend', 'DEFAULT_TARGET', 'available',
+           'resolve_target', 'select', 'current']
+
+DEFAULT_TARGET = 'python'
+
+_registry = {}
+_aliases = {}
+_current = None
+
+
+def register(backend):
+    if backend.id in _registry:
+        raise Exception(f'Duplicate language backend id: {backend.id}')
+    _registry[backend.id] = backend
+    for alias in backend.aliases:
+        if alias in _aliases:
+            raise Exception(f'Duplicate language backend alias: {alias}')
+        _aliases[alias] = backend.id
+
+
+def available():
+    return sorted(_registry)
+
+
+def resolve_target(name):
+    # Resolve a target by id or alias (case-insensitive); raise listing what is available.
+    key = (name or '').strip().lower()
+    if key in _registry:
+        return _registry[key]
+    if key in _aliases:
+        return _registry[_aliases[key]]
+    raise Exception(
+        f'Unknown target language: {name} (available: {", ".join(available())})')
+
+
+def select(name):
+    # Bind the target backend for this run (called once from the CLI). Returns the backend.
+    global _current
+    backend = resolve_target(name)
+    _current = backend
+    return backend
+
+
+def current():
+    # The backend bound for this run; defaults to the default target before any select().
+    global _current
+    if _current is None:
+        _current = resolve_target(DEFAULT_TARGET)
+    return _current
+
+
+register(PythonBackend())

--- a/marsha/backends/base.py
+++ b/marsha/backends/base.py
@@ -1,0 +1,131 @@
+"""The LanguageBackend interface.
+
+The core pipeline (llm.py / base.py / personas) is target-language-agnostic: it
+orchestrates the TDD methodology (oracle-first generation, diagnose -> fix,
+revert-on-regression guardrail, --optimize persona loops) and delegates every
+language-specific leaf to a LanguageBackend:
+
+- naming / artifact contract (source, test, manifest, fence language, layout)
+- generation and review prompts (full templates, owned per backend)
+- validation of LLM markdown output
+- compose (impl + oracle -> on-disk layout)
+- formatting, linting, test execution
+- the runnable-CLI step and per-backend reviewer guidance
+- toolchain detection
+
+Only `python` is wired in today; the registry in `marsha.backends` is ready for
+more (issue #204; Rust is the first follow-on, #183).
+"""
+
+
+class LanguageBackend:
+    """One target language's leaf operations. Subclasses implement every method."""
+
+    id = ''
+    aliases = ()
+    code_fence_lang = ''
+
+    # --- naming / contract ---------------------------------------------------
+
+    def source_name(self, fn):
+        """On-disk name of the implementation file for function name `fn`."""
+        raise NotImplementedError
+
+    def test_name(self, fn):
+        """On-disk name of the test suite (oracle) file for function name `fn`."""
+        raise NotImplementedError
+
+    def manifest_name(self):
+        """On-disk name of the dependency manifest, if the target has one."""
+        raise NotImplementedError
+
+    def artifact_contract(self, fn):
+        """Ordered (kind, filename) pairs making up the full artifact set for
+        function name `fn`. The single source of truth that the prompts describe
+        and compose()/validate_markdown() enforce."""
+        raise NotImplementedError
+
+    def code_block(self, code):
+        """Fence a snippet of source code for embedding in a prompt."""
+        return f'```{self.code_fence_lang}\n{code}\n```'
+
+    # --- generation / review prompts (full templates, per backend) -----------
+
+    def spec_check_prompt(self):
+        """System prompt for the spec sanity check (compilable? warnings/errors?)."""
+        raise NotImplementedError
+
+    def oracle_prompt(self, meta):
+        """System prompt generating the oracle (the test suite) from the assignment."""
+        raise NotImplementedError
+
+    def impl_prompt(self, meta):
+        """System prompt generating an implementation against the oracle."""
+        raise NotImplementedError
+
+    def diagnose_prompt(self):
+        """System prompt deciding whether a test failure is the impl's or a test's fault."""
+        raise NotImplementedError
+
+    def fix_impl_prompt(self, meta):
+        """System prompt fixing the implementation (the oracle is off-limits)."""
+        raise NotImplementedError
+
+    def correct_test_prompt(self, meta):
+        """System prompt for the spec-anchored test correction (the oracle punt-back)."""
+        raise NotImplementedError
+
+    def lint_fix_prompt(self, filename):
+        """System prompt fixing lint findings in a single file."""
+        raise NotImplementedError
+
+    # --- layout / validation --------------------------------------------------
+
+    def compose(self, impl, oracle):
+        """Compose an implementation doc and the canonical oracle doc into the
+        on-disk layout: an ordered {path: content} mapping. The oracle is
+        harness-owned and the impl is produced against it, so recomposing on
+        every write keeps the impl path from touching the oracle in any layout."""
+        raise NotImplementedError
+
+    def validate_markdown(self, doc, kind, name):
+        """Validate an LLM markdown response against the artifact contract.
+        kind is 'oracle' (the test suite; name is the function name), 'impl'
+        (implementation + optional manifest; name is the function name), or
+        'unit' (a single file whose first header must be `name` verbatim)."""
+        raise NotImplementedError
+
+    # --- toolchain leaves -------------------------------------------------------
+
+    def format_files(self, paths):
+        """Format the given source files in place (e.g. autopep8)."""
+        raise NotImplementedError
+
+    def lint_files(self, paths):
+        """Lint the given files and return {path: [finding, ...]}."""
+        raise NotImplementedError
+
+    async def run_tests(self, code, test, manifest, debug=False):
+        """Build/install/run the test suite. Returns (passed, results): passed is
+        None if the suite could not be run at all, False if it ran and failed,
+        True if it passed."""
+        raise NotImplementedError
+
+    def make_executable(self, path):
+        """Make a generated module a runnable CLI. Python appends the static
+        reflection helper; other targets may use an LLM iteration instead."""
+        raise NotImplementedError
+
+    def persona_guidance(self):
+        """Per-backend conventions injected into every reviewer persona run
+        (language/project specifics the shared, language-agnostic reviewer
+        bodies deliberately leave out)."""
+        raise NotImplementedError
+
+    def toolchain(self):
+        """The interpreter/compiler executable for the target (raises if missing)."""
+        raise NotImplementedError
+
+    def toolchain_ok(self):
+        """Whether the target toolchain is available (no raising)."""
+        raise NotImplementedError

--- a/marsha/backends/python.py
+++ b/marsha/backends/python.py
@@ -1,0 +1,512 @@
+"""The Python language backend.
+
+Reproduces the historical, Python-hardcoded behavior of the generation pipeline
+exactly: prompts, venv + pip test execution, pycodestyle/pyflakes linting,
+autopep8 formatting, the `.py` / `_test.py` / `requirements.txt` artifact
+contract, the runnable-`main` reflection helper, and `python`/`python3`
+toolchain detection. See issue #204.
+"""
+
+import asyncio
+import os
+import platform
+import shutil
+import subprocess
+
+import autopep8
+import pycodestyle
+import pyflakes.api
+from mistletoe import Document, ast_renderer
+
+from marsha.backends.base import LanguageBackend
+from marsha.meta import void_note
+from marsha.utils import read_file, write_file, run_subprocess
+
+# pyflakes findings that are style noise (the linter previously suppressed them); everything else
+# (e.g. undefined names) is a real problem worth showing the LLM.
+_PYFLAKES_NOISE = ('imported but unused',
+                   'is assigned to but never used', 'is defined but unused')
+
+# pycodestyle (style/syntax) + pyflakes (semantics), run directly: pylama was dropped because
+# it imports the deprecated pkg_resources API. We lint to catch coarse errors like undefined
+# names; we do not want the LLM fixing every style nit — the output goes through autopep8
+# anyway — so a large set of cosmetic rules is ignored below.
+_LINT_IGNORE = {
+    'E111',  # indentation is not multiple of 4
+    'E117',  # over-indented
+    'E126',  # continuation line over-indented for hanging indent
+    'E127',  # continuation line over-indented for visual indent
+    'E128',  # continuation line under-indented for visual indent
+    'E129',  # visually indented line with same indent as next logical line
+    'E131',  # continuation line unaligned for hanging indent
+    'E133',  # closing bracket is missing indentation
+    'E201',  # whitespace after `(`
+    'E202',  # whitespace before `)`
+    'E203',  # whitespace before `,` `;` `:`
+    'E211',  # whitespace before `(`'
+    'E221',  # multiple spaces before operator
+    'E222',  # multiple spaces after operator
+    'E223',  # tab before operator
+    'E224',  # tab after operator
+    'E225',  # missing whitespace around operator
+    'E226',  # missing whitespace around arithmetic operator
+    'E227',  # missing whitespace around bitwise or shift operator
+    'E228',  # missing whitespace around modulo operator
+    'E231',  # missing whitespace after `,` `;` `:`
+    'E241',  # multiple spaces after `,` `;` `:`
+    'E242',  # tab after `,` `;` `:`
+    'E251',  # unexpected spaces around keyword / parameter equals
+    'E252',  # missing whitespace around parameter equals
+    'E261',  # at least two spaces before inline comment
+    'E262',  # inline comment should start with `# `
+    'E265',  # block comment should start with `# `
+    'E266',  # too many `#` for block comment
+    'E271',  # multiple spaces after keyword
+    'E272',  # multiple spaces before keyword
+    'E273',  # tab before keyword
+    'E274',  # tab after keyword
+    'E275',  # space missing after keyword
+    'E301',  # expected 1 blank line, found 0
+    'E302',  # expected 2 blank lines, found 0
+    'E303',  # too many blank lines
+    'E304',  # blank line after function decorator
+    'E305',  # expected 2 blank lines after function or class
+    'E306',  # expected 1 blank line before nested definition
+    'E401',  # multiple imports on one line
+    'E501',  # line too long
+    'E502',  # blackslash redundant between brackets
+    'E701',  # multiple statements on one line (colon)
+    'E702',  # multiple statements on one line (semicolon)
+    'E703',  # statement ends with a semicolon
+    'E722',  # do not use bare except, specify exception instead
+    'E731',  # do not assign a lambda expression, use a def
+    'W191',  # indentation contains tabs
+    'W291',  # trailing whitespace
+    'W292',  # no newline at end of file
+    'W293',  # blank line contains whitespace
+    'W391',  # blank line at end of file
+    # https://github.com/AtomLinter/linter-pylama/blob/master/bin/pylama/lint/pylama_pyflakes.py
+    'W0404',  # module is reimported multiple times
+    'W0410',  # future import(s) after other imports
+    'W0611',  # unused import
+    'W0612',  # unused variable
+}
+
+
+class _StyleReport(pycodestyle.BaseReport):
+    """Collect pycodestyle findings as (line, col, code, message) tuples, honouring the ignore set."""
+
+    def __init__(self, options):
+        super().__init__(options)
+        self.errors = []
+
+    def error(self, line_number, offset, text, check):
+        code = super().error(line_number, offset, text, check)
+        if code:
+            self.errors.append((line_number, offset + 1, code, text[5:]))
+        return code
+
+    def get_file_results(self):
+        return len(self.errors)
+
+
+class _FlakeReport:
+    """Collect pyflakes findings (undefined names, syntax errors, ...) as preformatted strings."""
+
+    def __init__(self):
+        self.errors = []
+
+    def flake(self, message):
+        self.errors.append(str(message))
+
+    def syntaxError(self, filename, msg, lineno, offset, text):
+        if offset is not None:
+            self.errors.append(f'{filename}:{lineno}:{max(offset, 1)}: {msg}')
+        else:
+            self.errors.append(f'{filename}:{lineno}: {msg}')
+
+    def unexpectedError(self, filename, msg):
+        self.errors.append(f'{filename}: {msg}')
+
+
+class PythonBackend(LanguageBackend):
+    id = 'python'
+    aliases = ('py',)
+    code_fence_lang = 'py'
+
+    def __init__(self):
+        self._toolchain = None
+
+    # --- naming / contract ---------------------------------------------------
+
+    def source_name(self, fn):
+        return f'{fn}.py'
+
+    def test_name(self, fn):
+        return f'{fn}_test.py'
+
+    def manifest_name(self):
+        return 'requirements.txt'
+
+    def artifact_contract(self, fn):
+        return [
+            ('source', self.source_name(fn)),
+            ('manifest', self.manifest_name()),
+            ('test', self.test_name(fn)),
+        ]
+
+    # --- generation / review prompts (full templates) -------------------------
+
+    def spec_check_prompt(self):
+        return '''You are a senior software engineer reviewing an assignment to write a Python 3 function.
+The assignment is written in markdown format.
+It should include sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
+
+First, decide whether the document is compilable. Use this test: could at least one implementation exist that satisfies every part of the document (description, inputs, outputs, and all examples) at the same time? If such an implementation could exist, the document is compilable.
+Underspecification is not a reason the document is not compilable: like unspecified behavior in C, whatever the document leaves open is for the implementer to decide reasonably. If the description allows several outcomes (several valid orderings, several equivalent error messages, several formats) and the examples show one of them, an implementation that follows the examples satisfies the document, so it is compilable.
+One section adding more detail than another is not a contradiction: sections only conflict when they state opposing views on what the code should be doing.
+The document is not compilable only when no implementation could satisfy it as written, eg the description says the function prints its result while the examples compare its return value to a string, two examples give different outputs for the same input, or an example is malformed or violates a stated requirement.
+
+Second, list warnings for significant ambiguities. A warning is for an underspecified or ambiguous area that could result in differently-behaving code between independent generation runs, eg a missing exception type or message, missing edge cases, an ambiguous output precision or format, or non-deterministic behavior that would make the generated code flaky to test.
+Be careful not to wear out the user with useless warnings: only warn when the ambiguity is significant enough that two reasonable implementers could plausibly produce different behavior. Do not warn about style, and do not ask for more examples or more precision in areas that are merely unspecified but unlikely to change the behavior.
+
+Respond with a single JSON object and nothing else, in exactly this shape:
+{"compilable": true, "warnings": ["...", "..."]}
+When the document is not compilable, include a third key, an "errors" array with one or more entries:
+{"compilable": false, "warnings": ["..."], "errors": ["...", "..."]}
+Each warning and each error is a markdown-formatted string that cites the relevant portion of the document using inline quotes of the document's own words. Each error must quote the sections that conflict with each other and explain why no implementation could satisfy both.
+Do not wrap the JSON object in code fences.
+'''
+
+    def oracle_prompt(self, meta):
+        return f'''You are a senior software engineer assigned to write a unit test suite for Python 3 functions.
+The assignment is written in markdown format.
+The test suite is the *oracle* used to judge generated implementations, so it must be trustworthy.
+The unit tests created should exactly match the example cases provided for each function.
+You have to create a TestCase per function provided.
+{void_note(meta)}
+The filename should exactly match the name `{meta.filename}_test.py`.
+Unknown imports might come from the file where the function is defined, or from the standard library.
+If you are working with files, make sure to mock the file system since the tests will be run in a sandboxed environment.
+Make sure to follow PEP8 guidelines.
+Make sure to include all needed standard Python libraries imports.
+The tests must be faithful to the assignment:
+- Every test must correspond to an example of expected behavior in the assignment, or to behavior its description explicitly states.
+- Do not assert behavior the assignment does not state. Do not test implementation details, internal structure, or the exact wording of error messages or output formats unless the assignment pins them down.
+- Do not invent edge cases, inputs, or expected outputs that are not grounded in the assignment.
+Your response must not comment on what you changed.
+Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
+Your response must be a markdown file.
+The first section header must be the filename `{meta.filename}_test.py`.
+The content of the first section must be a python code block with the generated code.
+The file should end with the code block, nothing else should be added to the file.
+The desired response must look like the following:
+
+# {meta.filename}_test.py
+
+```py
+<generated code>
+```
+
+'''
+
+    def impl_prompt(self, meta):
+        return f'''You are a senior software engineer assigned to write Python 3 functions.
+The assignment is written in markdown format.
+The description of each function should be included as a docstring.
+Add type hints if feasible.
+The filename should exactly match the name `{meta.filename}.py`.
+Make sure to follow PEP8 guidelines.
+Make sure to include all needed standard Python libraries imports.
+Generate `requirements.txt` file with all needed dependencies, do not add fixed version to dependencies.
+If need to convert `type` to Python classes, you will receive a markdown where the heading is the class name followed by several rows following a comma separated CSV format where the first row contains all class properties and the following rows contain examples of the values of those properties. Make sure to add the __str__, __repr__, and __eq__ methods to the class.
+A unit test suite has already been written from this same assignment and is provided to you. Your implementation must satisfy the assignment AND pass this test suite. If anything in the test suite ever appears to conflict with the assignment, the assignment is authoritative.
+Your response must not comment on what you changed.
+Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
+Your response must be a markdown file.
+The first section header must be the filename `{meta.filename}.py`.
+The content of the first section must be a python code block with the generated code.
+The second section header must be the filename `requirements.txt`.
+The content of the second section must be a text code block with the generated code.
+The file should end with the code block, nothing else should be added to the file.
+The desired response must look like the following:
+
+# {meta.filename}.py
+
+```py
+<generated code>
+```
+
+# requirements.txt
+
+```txt
+<dependencies needed>
+```
+
+'''
+
+    def diagnose_prompt(self):
+        return '''You are a senior software engineer debugging a Python 3 project.
+You are given the assignment (in markdown), the implementation, the unit test suite (the oracle), and the unit test results.
+The test suite was derived from the assignment and is authoritative for what the code should do, except where a test is itself wrong.
+Determine the root cause of the failure:
+- "implementation": the code is at fault — it does not correctly implement the assignment (a bug, a missing edge case, wrong logic, a missing or wrong import, etc.).
+- "test": a test is at fault — it asserts behavior the assignment does not actually require (it is over-strict, it contradicts the assignment, it tests an implementation detail, or it pins down an exact error-message wording or output format that the assignment leaves open).
+Choose "test" only when the failing assertion is genuinely not required by the assignment; when in doubt, choose "implementation".
+Respond with a single JSON object and nothing else, in exactly this shape:
+{"fault": "implementation", "reason": "..."}
+or
+{"fault": "test", "reason": "..."}
+Do not wrap the JSON object in code fences.
+'''
+
+    def fix_impl_prompt(self, meta):
+        return f'''You are a senior software engineer fixing a Python 3 implementation that is failing its unit tests.
+You are given the assignment, the implementation, the unit test suite (the oracle), and the test results.
+The unit test suite is authoritative and must NOT be modified.
+Fix only the implementation so that it correctly implements the assignment and passes the test suite, making the least changes necessary.
+Make sure to produce working code that passes the unit tests.
+Make sure to follow PEP8 style guidelines.
+Make sure to include all needed standard Python libraries imports.
+Generate `requirements.txt` file with all needed dependencies, do not add fixed version to dependencies.
+Your response must not comment on what you changed.
+Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
+Your response must be a markdown file.
+The first section header must be the filename `{meta.filename}.py`.
+The content of the first section must be a python code block with the generated code.
+The second section header must be the filename `requirements.txt`.
+The content of the second section must be a text code block with the generated code.
+The file should end with the code block, nothing else should be added to the file.
+The desired response must look like the following:
+
+# {meta.filename}.py
+
+```py
+<fixed code>
+```
+
+# requirements.txt
+
+```txt
+<dependencies needed>
+```
+
+'''
+
+    def correct_test_prompt(self, meta):
+        return f'''You are a senior software engineer correcting a faulty unit test.
+You are given the assignment, the implementation, the unit test suite, and the test results.
+A diagnosis has determined that a TEST (not the implementation) is at fault: it asserts behavior the assignment does not actually require — for example it is over-strict, it contradicts the assignment, it tests an implementation detail, or it pins down an exact error-message wording or output format that the assignment leaves open.
+Correct ONLY the faulty test(s) so that the test suite faithfully tests the assignment. Every change you make must be justified by the assignment: reference the part of the assignment that makes the current test wrong.
+You must NOT weaken a test that is actually correct: if a failing assertion is genuinely required by the assignment, leave that test unchanged.
+You must NOT modify the implementation, and you must not write new tests beyond correcting the faulty ones.
+Your response must not comment on what you changed.
+Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
+Your response must be a markdown file.
+The first section header must be the filename `{meta.filename}_test.py`.
+The content of the first section must be a python code block with the corrected test code.
+The file should end with the code block, nothing else should be added to the file.
+The desired response must look like the following:
+
+# {meta.filename}_test.py
+
+```py
+<corrected code>
+```
+
+'''
+
+    def lint_fix_prompt(self, filename):
+        return f'''You are a senior software engineer working with Python 3.
+You are using a Python linter to find obvious errors and then fixing them. The linter uses `pyflakes` and `pycodestyle` under the hood to provide the recommendations.
+All of the lint errors require fixing.
+You should only fix the lint errors and not change anything else.
+Your response must not comment on what you changed.
+Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
+Your response must be a markdown file.
+The first section header must be the filename `{filename}`.
+The content of the first section must be a python code block with the generated code.
+The file should end with the code block, nothing else should be added to the file.
+The desired response must look like the following:
+
+# {filename}
+
+```py
+<fixed code>
+```
+
+'''
+
+    # --- layout / validation --------------------------------------------------
+
+    def _sections(self, md):
+        # The (header, content) pairs of a sectioned markdown doc, in document order. Empty code
+        # fences are skipped, mirroring write_files_from_markdown.
+        ast = ast_renderer.get_ast(Document(md))
+        sections = []
+        filename = ''
+        for section in ast['children']:
+            if section['type'] == 'Heading':
+                filename = section['children'][0]['content']
+            elif section['type'] == 'CodeFence':
+                filedata = section['children'][0]['content']
+                if filedata is None or filedata == '':
+                    continue
+                sections.append((filename, filedata))
+        return sections
+
+    def compose(self, impl, oracle):
+        # Implementation files first (in document order), then the oracle's files: the
+        # source file, the optional manifest, and the test suite.
+        files = {}
+        for name, content in self._sections(impl) + self._sections(oracle):
+            files[name] = content
+        return files
+
+    def _validate_single(self, md, filename):
+        # A single-file document: one header (the filename) followed by one code fence.
+        ast = ast_renderer.get_ast(Document(md))
+        if len(ast['children']) != 2:
+            return False
+        if ast['children'][0]['type'] != 'Heading':
+            return False
+        if ast['children'][1]['type'] != 'CodeFence':
+            return False
+        if ast['children'][0]['children'][0]['content'].strip() != filename:
+            return False
+        return True
+
+    def _validate_impl(self, md, marsha_filename):
+        # An implementation-only document: the code file, optionally followed by requirements.txt
+        ast = ast_renderer.get_ast(Document(md))
+        if len(ast['children']) != 2 and len(ast['children']) != 4:
+            return False
+        if ast['children'][0]['type'] != 'Heading':
+            return False
+        if ast['children'][1]['type'] != 'CodeFence':
+            return False
+        if ast['children'][0]['children'][0]['content'].strip() != f'{marsha_filename}.py':
+            return False
+        if len(ast['children']) == 4:
+            if ast['children'][2]['type'] != 'Heading':
+                return False
+            if ast['children'][3]['type'] != 'CodeFence':
+                return False
+            if ast['children'][2]['children'][0]['content'].strip() != 'requirements.txt':
+                return False
+        return True
+
+    def validate_markdown(self, doc, kind, name):
+        if kind == 'impl':
+            return self._validate_impl(doc, name)
+        if kind == 'oracle':
+            return self._validate_single(doc, self.test_name(name))
+        if kind == 'unit':
+            return self._validate_single(doc, name)
+        return False
+
+    # --- toolchain leaves -------------------------------------------------------
+
+    def format_files(self, files):
+        for file in files:
+            before = read_file(file)
+            after = autopep8.fix_code(before)
+            write_file(file, after)
+
+    def lint_files(self, files):
+        """Run pycodestyle (style/syntax) and pyflakes (semantics) over the given files and return a
+        mapping of filename -> list of '<file>:<line>:<col>: <code> <message>' strings. Replaces the
+        former pylama call, whose plugin discovery imports the deprecated pkg_resources API."""
+        findings = {f: [] for f in files}
+        style_options = pycodestyle.StyleGuide(
+            quiet=True, ignore=list(_LINT_IGNORE)).options
+        for file in files:
+            path = os.path.abspath(f'./{file}')
+            if not os.path.exists(path):
+                continue
+            style = _StyleReport(style_options)
+            pycodestyle.Checker(path, options=style_options,
+                                report=style).check_all()
+            findings[file].extend(f'{file}:{line}:{col}: {code} {msg}'
+                                  for line, col, code, msg in style.errors)
+            with open(path, encoding='utf-8') as fh:
+                source = fh.read()
+            flakes = _FlakeReport()
+            pyflakes.api.check(source, file, flakes)
+            for entry in flakes.errors:
+                if any(noise in entry for noise in _PYFLAKES_NOISE):
+                    continue
+                findings[file].append(entry)
+        return findings
+
+    async def run_tests(self, code_file, test_file, req_file, debug=False):
+        # Set up the venv (if needed), install requirements, and run the test suite.
+        # Returns (passed, results): passed is None if the suite could not be run at all,
+        # False if it ran but failed, and True if it passed.
+        python = self.toolchain()
+        code_file_dir = os.path.dirname(os.path.abspath(code_file))
+        venv_path = f'{code_file_dir}/venv'
+        if req_file and os.path.exists(req_file):
+            if not os.path.exists(venv_path):
+                print('Creating virtual environment...')
+                try:
+                    create_venv_stream = await asyncio.create_subprocess_exec(
+                        python, '-m', 'venv', venv_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    await run_subprocess(create_venv_stream)
+                except Exception as e:
+                    if debug:
+                        print('Failed to create virtual environment', e)
+            print('Installing requirements...')
+            try:
+                pip_exe = f'{venv_path}/Scripts/pip.exe' if platform.system(
+                ) == 'Windows' else f'{venv_path}/bin/pip'
+                pip_stream = await asyncio.create_subprocess_exec(
+                    pip_exe, 'install', '--disable-pip-version-check', '--no-compile', '-r', req_file, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                await run_subprocess(pip_stream, 120)
+            except Exception as e:
+                if debug:
+                    print('Failed to install requirements', e)
+        if not os.path.exists(venv_path):
+            python_exe = python
+        else:
+            python_exe = f'{venv_path}/Scripts/python.exe' if platform.system(
+            ) == 'Windows' else f'{venv_path}/bin/python'
+        try:
+            test_stream = await asyncio.create_subprocess_exec(
+                python_exe, test_file, '-f', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = await run_subprocess(test_stream)
+            results = f'''{stdout}{stderr}'''
+        except Exception as e:
+            print('Failed to run test suite...', e)
+            return (None, '')
+        passed = ('FAILED' not in results) and ('Traceback' not in results)
+        return (passed, results)
+
+    def make_executable(self, path):
+        # Append the static reflection `__main__` helper (no LLM involved).
+        helper = os.path.join(os.path.dirname(os.path.dirname(
+            os.path.abspath(__file__))), 'helper.py')
+        with open(path, 'a') as o, open(helper, 'r') as i:
+            o.write(i.read())
+
+    def persona_guidance(self):
+        return ('This project targets Python 3 — use type hints to aid static analysis, '
+                'follow PEP8, code is formatted with autopep8, and third-party '
+                'dependencies go in `requirements.txt`.')
+
+    def toolchain(self):
+        # Determine what name the user's `python` executable is (`python` or `python3`)
+        if self._toolchain is None:
+            name = 'python' if shutil.which(
+                'python') is not None else 'python3'
+            if shutil.which(name) is None:
+                raise Exception('Python not found')
+            self._toolchain = name
+        return self._toolchain
+
+    def toolchain_ok(self):
+        try:
+            self.toolchain()
+            return True
+        except Exception:
+            return False

--- a/marsha/base.py
+++ b/marsha/base.py
@@ -1,20 +1,19 @@
 import argparse
 import asyncio
-import os
 import tempfile
 import time
 import traceback
 
+from marsha import backends
 from marsha.config import (resolve_model, resolve_provider, resolve_api_base, is_local_backend,
                            set_cli_api_base, set_cli_model, set_cli_provider, apply_available_models)
 from marsha.context import discover_models
 from marsha import log
-from marsha.llm import generate_python_code, review_and_fix
+from marsha.llm import generate_code, review_and_fix
 from marsha.llm_client import create_client, set_client
 from marsha.meta import MarshaMeta
-from marsha.parse import write_files_from_markdown
 from marsha.stats import stats
-from marsha.utils import read_file, copy_file, add_helper, copy_tree, prettify_time_delta
+from marsha.utils import read_file, copy_file, copy_tree, prettify_time_delta, write_composed
 
 # Parse the input arguments
 parser = argparse.ArgumentParser(
@@ -22,6 +21,8 @@ parser = argparse.ArgumentParser(
     description='Marsha AI Compiler',
 )
 parser.add_argument('source')
+parser.add_argument('-t', '--target', default='python',
+                    help='Target language for the generated code, by backend id or alias (default: python). Only `python` is wired today; the registry is ready for more.')
 parser.add_argument('-d', '--debug', action='store_true',
                     help='Turn on debug logging')
 parser.add_argument('--trace', action='store_true',
@@ -86,7 +87,12 @@ set_client(client)
 if is_local_backend():
     for note in apply_available_models(discover_models(resolve_api_base())):
         print(f'Note: {note}')
+# Bind the target-language backend (--target) and verify its toolchain is available.
+target = backends.select(args.target)
+if not target.toolchain_ok():
+    raise Exception(f'{args.target} toolchain not found')
 if args.debug or args.trace or args.trace_full:
+    print(f'Using target language: {target.id}')
     print(f'Using LLM provider: {resolve_provider()}')
     print(f'Using LLM endpoint: {client.base_url}')
     print(f'Using LLM model: {resolve_model()}')
@@ -107,31 +113,32 @@ async def main():
     if debug:
         print(f'Number of attempts: {attempts}')
         print(f'Number of parallel executions: {n_results}')
+    backend = backends.current()
     while attempts:
         attempts = attempts - 1
         # First stage: generate code for functions and classes
         try:
-            mds = await generate_python_code(args, meta, n_results, debug)
+            cands = await generate_code(args, meta, n_results, debug)
         except Exception:
             continue
         # Early exit if quick and dirty
         if quick_and_dirty:
             print('Writing generated code to files...')
-            for md in mds[:2]:
-                write_files_from_markdown(md)
+            for impl, oracle in cands[:2]:
+                write_composed(backend.compose(impl, oracle))
             attempts = attempts + 1
             break
         # Writing generated code to temporary files in preparation for next stages
         file_groups = list()
         tmp_directories = []
-        for idx, md in enumerate(mds):
+        for idx, (impl, oracle) in enumerate(cands):
             print('Writing generated code to temporary files...')
             tmpdir = tempfile.TemporaryDirectory(
                 suffix=f'_-_{meta.filename}_{idx}')
             tmp_directories.append(tmpdir)
             file_groups = file_groups + \
-                [write_files_from_markdown(
-                    md, subdir=tmpdir.name)]
+                [write_composed(
+                    backend.compose(impl, oracle), subdir=tmpdir.name)]
         if debug:
             for filename in [filename for file_group in file_groups for filename in file_group]:
                 print(f'# {filename}\n{read_file(filename)}\n')
@@ -143,17 +150,18 @@ async def main():
         try:
             done_task_name = await run_parallel_tasks(tasks)
             print('Writing generated code to files...')
-            filename = done_task_name
-            copy_file(filename, f'{meta.filename}.py')
+            group = [g for g in file_groups if g[0] == done_task_name][0]
+            source_dest = backend.source_name(meta.filename)
+            copy_file(done_task_name, source_dest)
             if not args.exclude_main_helper:
-                add_helper(f'{meta.filename}.py')
-            test_filename = filename.replace('.py', '_test.py')
-            copy_file(test_filename, f'{meta.filename}_test.py')
-            directory = os.path.dirname(filename)
-            requirements_filename = os.path.join(
-                directory, 'requirements.txt')
-            if os.path.exists(requirements_filename):
-                copy_file(requirements_filename, 'requirements.txt')
+                backend.make_executable(source_dest)
+            test_file = [f for f in group if f.endswith(
+                backend.test_name(meta.filename))][0]
+            copy_file(test_file, backend.test_name(meta.filename))
+            manifests = [f for f in group if f.endswith(
+                backend.manifest_name())]
+            if len(manifests) > 0:
+                copy_file(manifests[0], backend.manifest_name())
         except Exception as e:
             print('Failed to generate working code.')
             print(e)

--- a/marsha/llm.py
+++ b/marsha/llm.py
@@ -1,23 +1,17 @@
 import asyncio
-from asyncio.subprocess import Process
 import json
 import os
-import platform
 import re
 import time
 import traceback
-import shutil
-import subprocess
 import sys
 
-import pycodestyle
-import pyflakes.api
-
+from marsha import backends
 from marsha.config import resolve_model, resolve_provider, resolve_strong_model
 from marsha.context import budget_tokens, estimate_tokens, fits, resolve_context_window
-from marsha.meta import MarshaMeta
+from marsha.meta import MarshaMeta, void_note
 from marsha.log import log
-from marsha.parse import validate_first_stage_markdown, validate_second_stage_markdown, validate_impl_markdown, write_files_from_markdown, format_marsha_for_llm, extract_func_name, split_preamble
+from marsha.parse import write_files_from_markdown, format_marsha_for_llm, split_preamble
 from marsha.personas import (
     build_registry, resolve_loop_reviewers, load_editor, run_personas,
     actionable_findings, format_findings, prior_round_block, parse_severities,
@@ -25,50 +19,10 @@ from marsha.personas import (
 )
 from marsha.stats import stats
 from marsha.term import print_diagnostic
-from marsha.utils import read_file, write_file, autoformat_files, prettify_time_delta
+from marsha.utils import read_file, write_file, prettify_time_delta
 from marsha.llm_client import get_client
 from marsha.mappers import get_mapper
 from marsha.mappers.chatgpt import uses_completion_tokens
-
-# Determine what name the user's `python` executable is (`python` or `python3`)
-python = 'python' if shutil.which('python') is not None else 'python3'
-if shutil.which(python) is None:
-    raise Exception('Python not found')
-
-
-SPEC_CHECK_PROMPT = '''You are a senior software engineer reviewing an assignment to write a Python 3 function.
-The assignment is written in markdown format.
-It should include sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.
-
-First, decide whether the document is compilable. Use this test: could at least one implementation exist that satisfies every part of the document (description, inputs, outputs, and all examples) at the same time? If such an implementation could exist, the document is compilable.
-Underspecification is not a reason the document is not compilable: like unspecified behavior in C, whatever the document leaves open is for the implementer to decide reasonably. If the description allows several outcomes (several valid orderings, several equivalent error messages, several formats) and the examples show one of them, an implementation that follows the examples satisfies the document, so it is compilable.
-One section adding more detail than another is not a contradiction: sections only conflict when they state opposing views on what the code should be doing.
-The document is not compilable only when no implementation could satisfy it as written, eg the description says the function prints its result while the examples compare its return value to a string, two examples give different outputs for the same input, or an example is malformed or violates a stated requirement.
-
-Second, list warnings for significant ambiguities. A warning is for an underspecified or ambiguous area that could result in differently-behaving code between independent generation runs, eg a missing exception type or message, missing edge cases, an ambiguous output precision or format, or non-deterministic behavior that would make the generated code flaky to test.
-Be careful not to wear out the user with useless warnings: only warn when the ambiguity is significant enough that two reasonable implementers could plausibly produce different behavior. Do not warn about style, and do not ask for more examples or more precision in areas that are merely unspecified but unlikely to change the behavior.
-
-Respond with a single JSON object and nothing else, in exactly this shape:
-{"compilable": true, "warnings": ["...", "..."]}
-When the document is not compilable, include a third key, an "errors" array with one or more entries:
-{"compilable": false, "warnings": ["..."], "errors": ["...", "..."]}
-Each warning and each error is a markdown-formatted string that cites the relevant portion of the document using inline quotes of the document's own words. Each error must quote the sections that conflict with each other and explain why no implementation could satisfy both.
-Do not wrap the JSON object in code fences.
-'''
-
-DIAGNOSE_PROMPT = '''You are a senior software engineer debugging a Python 3 project.
-You are given the assignment (in markdown), the implementation, the unit test suite (the oracle), and the unit test results.
-The test suite was derived from the assignment and is authoritative for what the code should do, except where a test is itself wrong.
-Determine the root cause of the failure:
-- "implementation": the code is at fault — it does not correctly implement the assignment (a bug, a missing edge case, wrong logic, a missing or wrong import, etc.).
-- "test": a test is at fault — it asserts behavior the assignment does not actually require (it is over-strict, it contradicts the assignment, it tests an implementation detail, or it pins down an exact error-message wording or output format that the assignment leaves open).
-Choose "test" only when the failing assertion is genuinely not required by the assignment; when in doubt, choose "implementation".
-Respond with a single JSON object and nothing else, in exactly this shape:
-{"fault": "implementation", "reason": "..."}
-or
-{"fault": "test", "reason": "..."}
-Do not wrap the JSON object in code fences.
-'''
 
 
 def parse_spec_check(text):
@@ -134,7 +88,7 @@ async def gpt_check_spec(meta: MarshaMeta, retries: int = 2):
     else:
         # Local OpenAI-compatible servers: leave the output budget to the server
         answer = {}
-    gpt_check = get_mapper(SPEC_CHECK_PROMPT, n_results=1,
+    gpt_check = get_mapper(backends.current().spec_check_prompt(), n_results=1,
                            stats_stage='first_stage', label='spec-check', **answer)
     marsha_for_code_llm = format_marsha_for_llm(meta)
     try:
@@ -148,41 +102,9 @@ async def gpt_check_spec(meta: MarshaMeta, retries: int = 2):
 async def gpt_test_suite(meta: MarshaMeta, retries: int = 3, debug: bool = False):
     # Generate the oracle (the test suite) first, anchored to the spec. This is the
     # authoritative artifact the implementation will be judged against.
-    void_function_names = list(
-        map(lambda f: extract_func_name(f), meta.void_funcs))
-    void_note = ''
-    if len(void_function_names) > 0:
-        void_note = f'Do not create any tests for the void functions: {", ".join(void_function_names)}.'
-    gpt_gen_test = get_mapper(f'''You are a senior software engineer assigned to write a unit test suite for Python 3 functions.
-The assignment is written in markdown format.
-The test suite is the *oracle* used to judge generated implementations, so it must be trustworthy.
-The unit tests created should exactly match the example cases provided for each function.
-You have to create a TestCase per function provided.
-{void_note}
-The filename should exactly match the name `{meta.filename}_test.py`.
-Unknown imports might come from the file where the function is defined, or from the standard library.
-If you are working with files, make sure to mock the file system since the tests will be run in a sandboxed environment.
-Make sure to follow PEP8 guidelines.
-Make sure to include all needed standard Python libraries imports.
-The tests must be faithful to the assignment:
-- Every test must correspond to an example of expected behavior in the assignment, or to behavior its description explicitly states.
-- Do not assert behavior the assignment does not state. Do not test implementation details, internal structure, or the exact wording of error messages or output formats unless the assignment pins them down.
-- Do not invent edge cases, inputs, or expected outputs that are not grounded in the assignment.
-Your response must not comment on what you changed.
-Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
-Your response must be a markdown file.
-The first section header must be the filename `{meta.filename}_test.py`.
-The content of the first section must be a python code block with the generated code.
-The file should end with the code block, nothing else should be added to the file.
-The desired response must look like the following:
-
-# {meta.filename}_test.py
-
-```py
-<generated code>
-```
-
-''', n_results=1, stats_stage='first_stage', label='oracle-gen')
+    b = backends.current()
+    gpt_gen_test = get_mapper(b.oracle_prompt(meta), n_results=1,
+                              stats_stage='first_stage', label='oracle-gen')
     marsha_for_test_llm = format_marsha_for_llm(meta)
     if debug:
         print(f'''marsha_for_llm =
@@ -191,7 +113,7 @@ The desired response must look like the following:
     ---- end ----''')
     try:
         doc = await gpt_gen_test.run(marsha_for_test_llm)
-        if not validate_second_stage_markdown(doc, f'{meta.filename}_test.py'):
+        if not b.validate_markdown(doc, 'oracle', meta.filename):
             if debug:
                 print(f'''[Oracle] Invalid doc:
 {doc}''')
@@ -207,30 +129,22 @@ The desired response must look like the following:
             raise Exception('Failed to generate test suite', meta.filename)
 
 
-def _void_note(meta: MarshaMeta):
-    # Note telling the oracle-related prompts not to test the void functions.
-    void_function_names = list(
-        map(lambda f: extract_func_name(f), meta.void_funcs))
-    if len(void_function_names) == 0:
-        return ''
-    return f'Do not create any tests for the void functions: {", ".join(void_function_names)}.'
-
-
 async def _run_editor(loop, meta, user_message, model, stats_stage, debug=False, retries=2):
     # One implementor (editor) iteration: load the loop's editor prompt, run it, and split its
     # response into (preamble, artifact). Returns (artifact, preamble), or (None, '') on failure.
+    b = backends.current()
     _, system = load_editor(loop)
-    system = system.format(filename=meta.filename, void_note=_void_note(meta))
+    system = system.format(filename=meta.filename, void_note=void_note(meta))
     if loop == 'impl':
-        first_header = f'{meta.filename}.py'
+        first_header = b.source_name(meta.filename)
 
         def validate(artifact):
-            return validate_impl_markdown(artifact, meta.filename)
+            return b.validate_markdown(artifact, 'impl', meta.filename)
     else:
-        first_header = f'{meta.filename}_test.py'
+        first_header = b.test_name(meta.filename)
 
         def validate(artifact):
-            return validate_second_stage_markdown(artifact, first_header)
+            return b.validate_markdown(artifact, 'oracle', meta.filename)
     for attempt in range(retries):
         try:
             mapper = get_mapper(system, n_results=1,
@@ -331,7 +245,7 @@ async def _budgeted_findings(meta, findings, build, model, args, debug=False):
 
 def _oracle_review_message(meta, oracle_md):
     return f'''{format_marsha_for_llm(meta)}
-{_void_note(meta)}
+{void_note(meta)}
 
 # The current test suite (oracle)
 
@@ -366,7 +280,8 @@ async def optimize_test_suite(meta: MarshaMeta, oracle_md: str, args, debug: boo
         user_message = _oracle_review_message(meta, oracle_md)
         if i > 0:
             user_message += prior_round_block(prior_findings, prior_preamble)
-        findings = await run_personas(reviewers, user_message, model, 'first_stage', debug, loop='oracle')
+        findings = await run_personas(reviewers, user_message, model, 'first_stage', debug,
+                                      loop='oracle', guidance=backends.current().persona_guidance())
         actionable = actionable_findings(findings, severities)
         if not actionable:
             if debug:
@@ -401,40 +316,10 @@ async def optimize_test_suite(meta: MarshaMeta, oracle_md: str, args, debug: boo
 async def gpt_implementation(meta: MarshaMeta, oracle_md: str, n_results: int, retries: int = 3, debug: bool = False):
     # Generate implementations against the (already generated) oracle. The implementation
     # must satisfy the spec AND pass the provided test suite; on any conflict the spec wins.
+    b = backends.current()
     marsha_for_code_llm = format_marsha_for_llm(meta)
-    gpt_gen_code = get_mapper(f'''You are a senior software engineer assigned to write Python 3 functions.
-The assignment is written in markdown format.
-The description of each function should be included as a docstring.
-Add type hints if feasible.
-The filename should exactly match the name `{meta.filename}.py`.
-Make sure to follow PEP8 guidelines.
-Make sure to include all needed standard Python libraries imports.
-Generate `requirements.txt` file with all needed dependencies, do not add fixed version to dependencies.
-If need to convert `type` to Python classes, you will receive a markdown where the heading is the class name followed by several rows following a comma separated CSV format where the first row contains all class properties and the following rows contain examples of the values of those properties. Make sure to add the __str__, __repr__, and __eq__ methods to the class.
-A unit test suite has already been written from this same assignment and is provided to you. Your implementation must satisfy the assignment AND pass this test suite. If anything in the test suite ever appears to conflict with the assignment, the assignment is authoritative.
-Your response must not comment on what you changed.
-Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
-Your response must be a markdown file.
-The first section header must be the filename `{meta.filename}.py`.
-The content of the first section must be a python code block with the generated code.
-The second section header must be the filename `requirements.txt`.
-The content of the second section must be a text code block with the generated code.
-The file should end with the code block, nothing else should be added to the file.
-The desired response must look like the following:
-
-# {meta.filename}.py
-
-```py
-<generated code>
-```
-
-# requirements.txt
-
-```txt
-<dependencies needed>
-```
-
-''', n_results=n_results, stats_stage='first_stage', label='impl-gen')
+    gpt_gen_code = get_mapper(b.impl_prompt(meta), n_results=n_results,
+                              stats_stage='first_stage', label='impl-gen')
     user_request = f'''{marsha_for_code_llm}
 
 ## The unit test suite your implementation must pass
@@ -454,7 +339,7 @@ The desired response must look like the following:
     try:
         mds = list()
         for doc in reses:
-            if validate_impl_markdown(doc, meta.filename):
+            if b.validate_markdown(doc, 'impl', meta.filename):
                 mds.append(doc)
             else:
                 if debug:
@@ -474,50 +359,8 @@ The desired response must look like the following:
             raise Exception('Failed to generate code', meta.filename)
 
 
-async def run_test_suite(code_file: str, test_file: str, req_file: str, debug: bool = False):
-    # Set up the venv (if needed), install requirements, and run the test suite.
-    # Returns (passed, results): passed is None if the suite could not be run at all,
-    # False if it ran but failed, and True if it passed.
-    code_file_dir = os.path.dirname(os.path.abspath(code_file))
-    venv_path = f'{code_file_dir}/venv'
-    if req_file and os.path.exists(req_file):
-        if not os.path.exists(venv_path):
-            print('Creating virtual environment...')
-            try:
-                create_venv_stream = await asyncio.create_subprocess_exec(
-                    python, '-m', 'venv', venv_path, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                await run_subprocess(create_venv_stream)
-            except Exception as e:
-                if debug:
-                    print('Failed to create virtual environment', e)
-        print('Installing requirements...')
-        try:
-            pip_exe = f'{venv_path}/Scripts/pip.exe' if platform.system(
-            ) == 'Windows' else f'{venv_path}/bin/pip'
-            pip_stream = await asyncio.create_subprocess_exec(
-                pip_exe, 'install', '--disable-pip-version-check', '--no-compile', '-r', req_file, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            await run_subprocess(pip_stream, 120)
-        except Exception as e:
-            if debug:
-                print('Failed to install requirements', e)
-    if not os.path.exists(venv_path):
-        python_exe = python
-    else:
-        python_exe = f'{venv_path}/Scripts/python.exe' if platform.system(
-        ) == 'Windows' else f'{venv_path}/bin/python'
-    try:
-        test_stream = await asyncio.create_subprocess_exec(
-            python_exe, test_file, '-f', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = await run_subprocess(test_stream)
-        results = f'''{stdout}{stderr}'''
-    except Exception as e:
-        print('Failed to run test suite...', e)
-        return (None, '')
-    passed = ('FAILED' not in results) and ('Traceback' not in results)
-    return (passed, results)
-
-
 def _impl_review_message(meta, oracle, code):
+    b = backends.current()
     return f'''{format_marsha_for_llm(meta)}
 
 # The unit test suite (oracle) the implementation must keep passing
@@ -526,12 +369,11 @@ def _impl_review_message(meta, oracle, code):
 
 # The current implementation
 
-```py
-{code}
-```'''
+{b.code_block(code)}'''
 
 
 def _impl_editor_message(meta, oracle, code, findings):
+    b = backends.current()
     return f'''{format_marsha_for_llm(meta)}
 
 # The unit test suite (oracle) the implementation must keep passing
@@ -540,9 +382,7 @@ def _impl_editor_message(meta, oracle, code, findings):
 
 # The current implementation
 
-```py
-{code}
-```
+{b.code_block(code)}
 
 # Review findings to address
 
@@ -556,11 +396,12 @@ async def optimize_implementation(args, meta: MarshaMeta, files: list[str], debu
     level = args.optimize
     if level <= 0:
         return
+    b = backends.current()
     code_file = [file for file in files if file.endswith(
-        f'{meta.filename}.py')][0]
+        b.source_name(meta.filename))][0]
     test_file = [file for file in files if file.endswith(
-        f'{meta.filename}_test.py')][0]
-    req_files = [file for file in files if file.endswith('requirements.txt')]
+        b.test_name(meta.filename))][0]
+    req_files = [file for file in files if file.endswith(b.manifest_name())]
     req_file = req_files[0] if len(req_files) > 0 else None
     subdir = os.path.dirname(os.path.abspath(code_file))
     oracle = read_file(test_file)
@@ -575,7 +416,8 @@ async def optimize_implementation(args, meta: MarshaMeta, files: list[str], debu
         user_message = _impl_review_message(meta, oracle, current_code)
         if i > 0:
             user_message += prior_round_block(prior_findings, prior_preamble)
-        findings = await run_personas(reviewers, user_message, model, 'third_stage', debug, loop='impl')
+        findings = await run_personas(reviewers, user_message, model, 'third_stage', debug,
+                                      loop='impl', guidance=b.persona_guidance())
         actionable = actionable_findings(findings, severities)
         if not actionable:
             if debug:
@@ -604,7 +446,7 @@ async def optimize_implementation(args, meta: MarshaMeta, files: list[str], debu
                 print(
                     f'[Optimize impl] iteration {i + 1}: unchanged, converged')
             break
-        passed, _ = await run_test_suite(code_file, test_file, req_file, debug)
+        passed, _ = await b.run_tests(code_file, test_file, req_file, debug)
         if passed:
             if debug:
                 print(f'[Optimize impl] iteration {i + 1}: improvement kept')
@@ -620,31 +462,13 @@ async def optimize_implementation(args, meta: MarshaMeta, files: list[str], debu
 
 
 async def fix_file(marsha_filename: str, filename: str, lint_text: str, retries: int = 3, debug: bool = False):
+    b = backends.current()
     code = read_file(filename)
-    gpt_fix = get_mapper(f'''You are a senior software engineer working with Python 3.
-You are using a Python linter to find obvious errors and then fixing them. The linter uses `pyflakes` and `pycodestyle` under the hood to provide the recommendations.
-All of the lint errors require fixing.
-You should only fix the lint errors and not change anything else.
-Your response must not comment on what you changed.
-Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
-Your response must be a markdown file.
-The first section header must be the filename `{filename}`.
-The content of the first section must be a python code block with the generated code.
-The file should end with the code block, nothing else should be added to the file.
-The desired response must look like the following:
-
-# {filename}
-
-```py
-<fixed code>
-```
-
-''', stats_stage='second_stage', label='lint-fix')
+    gpt_fix = get_mapper(b.lint_fix_prompt(filename),
+                         stats_stage='second_stage', label='lint-fix')
     fixed_code = await gpt_fix.run(f'''# {filename}
 
-```py
-{code}
-```
+{b.code_block(code)}
 
 # lint results
 
@@ -654,7 +478,7 @@ The desired response must look like the following:
     # The output should be a valid Markdown document. Parse it and return the parsed doc, on failure
     # try again (or fully error out, for now)
     try:
-        if not validate_second_stage_markdown(fixed_code, filename):
+        if not b.validate_markdown(fixed_code, 'unit', filename):
             if debug:
                 print(f'''[Second stage] Invalid doc:
 {fixed_code}''')
@@ -667,144 +491,13 @@ The desired response must look like the following:
             raise Exception('Failed to generate code', lint_text)
 
 
-class _StyleReport(pycodestyle.BaseReport):
-    """Collect pycodestyle findings as (line, col, code, message) tuples, honouring the ignore set."""
-
-    def __init__(self, options):
-        super().__init__(options)
-        self.errors = []
-
-    def error(self, line_number, offset, text, check):
-        code = super().error(line_number, offset, text, check)
-        if code:
-            self.errors.append((line_number, offset + 1, code, text[5:]))
-        return code
-
-    def get_file_results(self):
-        return len(self.errors)
-
-
-class _FlakeReport:
-    """Collect pyflakes findings (undefined names, syntax errors, ...) as preformatted strings."""
-
-    def __init__(self):
-        self.errors = []
-
-    def flake(self, message):
-        self.errors.append(str(message))
-
-    def syntaxError(self, filename, msg, lineno, offset, text):
-        if offset is not None:
-            self.errors.append(f'{filename}:{lineno}:{max(offset, 1)}: {msg}')
-        else:
-            self.errors.append(f'{filename}:{lineno}: {msg}')
-
-    def unexpectedError(self, filename, msg):
-        self.errors.append(f'{filename}: {msg}')
-
-
-# pyflakes findings that are style noise (the linter previously suppressed them); everything else
-# (e.g. undefined names) is a real problem worth showing the LLM.
-_PYFLAKES_NOISE = ('imported but unused',
-                   'is assigned to but never used', 'is defined but unused')
-
-
-def _lint_files(files, ignore):
-    """Run pycodestyle (style/syntax) and pyflakes (semantics) over the given files and return a
-    mapping of filename -> list of '<file>:<line>:<col>: <code> <message>' strings. Replaces the
-    former pylama call, whose plugin discovery imports the deprecated pkg_resources API."""
-    findings = {f: [] for f in files}
-    style_options = pycodestyle.StyleGuide(
-        quiet=True, ignore=list(ignore)).options
-    for file in files:
-        path = os.path.abspath(f'./{file}')
-        if not os.path.exists(path):
-            continue
-        style = _StyleReport(style_options)
-        pycodestyle.Checker(path, options=style_options,
-                            report=style).check_all()
-        findings[file].extend(f'{file}:{line}:{col}: {code} {msg}'
-                              for line, col, code, msg in style.errors)
-        with open(path, encoding='utf-8') as fh:
-            source = fh.read()
-        flakes = _FlakeReport()
-        pyflakes.api.check(source, file, flakes)
-        for entry in flakes.errors:
-            if any(noise in entry for noise in _PYFLAKES_NOISE):
-                continue
-            findings[file].append(entry)
-    return findings
-
-
 async def lint_and_fix_files(marsha_filename: str, files: list[str], max_depth: int = 4, debug: bool = False):
     if max_depth == 0:
         raise Exception('Failed to fix code', files)
-    # pycodestyle (style/syntax) + pyflakes (semantics), run directly: pylama was dropped because
-    # it imports the deprecated pkg_resources API. We lint to catch coarse errors like undefined
-    # names; we do not want the LLM fixing every style nit — the output goes through Black anyway —
-    # so a large set of cosmetic rules is ignored below.
-    _lint_ignore = {
-        'E111',  # indentation is not multiple of 4
-        'E117',  # over-indented
-        'E126',  # continuation line over-indented for hanging indent
-        'E127',  # continuation line over-indented for visual indent
-        'E128',  # continuation line under-indented for visual indent
-        'E129',  # visually indented line with same indent as next logical line
-        'E131',  # continuation line unaligned for hanging indent
-        'E133',  # closing bracket is missing indentation
-        'E201',  # whitespace after `(`
-        'E202',  # whitespace before `)`
-        'E203',  # whitespace before `,` `;` `:`
-        'E211',  # whitespace before `(`'
-        'E221',  # multiple spaces before operator
-        'E222',  # multiple spaces after operator
-        'E223',  # tab before operator
-        'E224',  # tab after operator
-        'E225',  # missing whitespace around operator
-        'E226',  # missing whitespace around arithmetic operator
-        'E227',  # missing whitespace around bitwise or shift operator
-        'E228',  # missing whitespace around modulo operator
-        'E231',  # missing whitespace after `,` `;` `:`
-        'E241',  # multiple spaces after `,` `;` `:`
-        'E242',  # tab after `,` `;` `:`
-        'E251',  # unexpected spaces around keyword / parameter equals
-        'E252',  # missing whitespace around parameter equals
-        'E261',  # at least two spaces before inline comment
-        'E262',  # inline comment should start with `# `
-        'E265',  # block comment should start with `# `
-        'E266',  # too many `#` for block comment
-        'E271',  # multiple spaces after keyword
-        'E272',  # multiple spaces before keyword
-        'E273',  # tab before keyword
-        'E274',  # tab after keyword
-        'E275',  # space missing after keyword
-        'E301',  # expected 1 blank line, found 0
-        'E302',  # expected 2 blank lines, found 0
-        'E303',  # too many blank lines
-        'E304',  # blank line after function decorator
-        'E305',  # expected 2 blank lines after function or class
-        'E306',  # expected 1 blank line before nested definition
-        'E401',  # multiple imports on one line
-        'E501',  # line too long
-        'E502',  # blackslash redundant between brackets
-        'E701',  # multiple statements on one line (colon)
-        'E702',  # multiple statements on one line (semicolon)
-        'E703',  # statement ends with a semicolon
-        'E722',  # do not use bare except, specify exception instead
-        'E731',  # do not assign a lambda expression, use a def
-        'W191',  # indentation contains tabs
-        'W291',  # trailing whitespace
-        'W292',  # no newline at end of file
-        'W293',  # blank line contains whitespace
-        'W391',  # blank line at end of file
-        # https://github.com/AtomLinter/linter-pylama/blob/master/bin/pylama/lint/pylama_pyflakes.py
-        'W0404',  # module is reimported multiple times
-        'W0410',  # future import(s) after other imports
-        'W0611',  # unused import
-        'W0612',  # unused variable
-    }
-
-    lints_by_file = _lint_files(files, _lint_ignore)
+    # The backend lints (style + semantics) with the target toolchain; we lint to catch coarse
+    # errors like undefined names, not every style nit — the output goes through the backend
+    # formatter anyway.
+    lints_by_file = backends.current().lint_files(files)
 
     if all(len(v) == 0 for v in lints_by_file.values()):
         return
@@ -821,41 +514,21 @@ async def lint_and_fix_files(marsha_filename: str, files: list[str], max_depth: 
     await lint_and_fix_files(marsha_filename, files, max_depth - 1, debug)
 
 
-async def run_subprocess(stream: Process, timeout: float = 60.0) -> tuple[str, str]:
-    stdout = ''
-    stderr = ''
-    try:
-        stdout, stderr = await asyncio.wait_for(stream.communicate(), timeout)
-    except asyncio.exceptions.TimeoutError:
-        try:
-            stream.kill()
-        except OSError:
-            # Ignore 'no such process' error
-            pass
-        raise Exception('run_subprocess timeout...')
-    except Exception as e:
-        raise e
-    return (stdout.decode('utf-8'), stderr.decode('utf-8'))
-
-
 async def diagnose_failure(meta: MarshaMeta, code: str, tests: str, results: str, retries: int = 2):
     # Read-only: decide whether the implementation or a test is at fault. Uses the standard
     # (cheap) model, since the safety property is enforced structurally, not by this call.
-    gpt_diag = get_mapper(DIAGNOSE_PROMPT, n_results=1,
+    b = backends.current()
+    gpt_diag = get_mapper(b.diagnose_prompt(), n_results=1,
                           stats_stage='third_stage', label='diagnose')
     user_request = f'''{format_marsha_for_llm(meta)}
 
-# {meta.filename}.py
+# {b.source_name(meta.filename)}
 
-```py
-{code}
-```
+{b.code_block(code)}
 
-# {meta.filename}_test.py
+# {b.test_name(meta.filename)}
 
-```py
-{tests}
-```
+{b.code_block(tests)}
 
 # Test Results
 
@@ -872,50 +545,18 @@ async def diagnose_failure(meta: MarshaMeta, code: str, tests: str, results: str
 async def fix_implementation(meta: MarshaMeta, code: str, tests: str, results: str, reason: str, retries: int = 3, debug: bool = False):
     # Edit ONLY the implementation. The oracle is provided as fixed context and is never
     # part of the editable output, so this path structurally cannot touch the test suite.
-    gpt_fix = get_mapper(f'''You are a senior software engineer fixing a Python 3 implementation that is failing its unit tests.
-You are given the assignment, the implementation, the unit test suite (the oracle), and the test results.
-The unit test suite is authoritative and must NOT be modified.
-Fix only the implementation so that it correctly implements the assignment and passes the test suite, making the least changes necessary.
-Make sure to produce working code that passes the unit tests.
-Make sure to follow PEP8 style guidelines.
-Make sure to include all needed standard Python libraries imports.
-Generate `requirements.txt` file with all needed dependencies, do not add fixed version to dependencies.
-Your response must not comment on what you changed.
-Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
-Your response must be a markdown file.
-The first section header must be the filename `{meta.filename}.py`.
-The content of the first section must be a python code block with the generated code.
-The second section header must be the filename `requirements.txt`.
-The content of the second section must be a text code block with the generated code.
-The file should end with the code block, nothing else should be added to the file.
-The desired response must look like the following:
-
-# {meta.filename}.py
-
-```py
-<fixed code>
-```
-
-# requirements.txt
-
-```txt
-<dependencies needed>
-```
-
-''', model=resolve_strong_model(), stats_stage='third_stage', label='impl-fix')
+    b = backends.current()
+    gpt_fix = get_mapper(b.fix_impl_prompt(meta), model=resolve_strong_model(),
+                         stats_stage='third_stage', label='impl-fix')
     user_request = f'''{format_marsha_for_llm(meta)}
 
-# {meta.filename}.py
+# {b.source_name(meta.filename)}
 
-```py
-{code}
-```
+{b.code_block(code)}
 
-# {meta.filename}_test.py
+# {b.test_name(meta.filename)}
 
-```py
-{tests}
-```
+{b.code_block(tests)}
 
 # Test Results
 
@@ -926,7 +567,7 @@ The desired response must look like the following:
 The implementation is at fault: {reason}'''
     fixed_code = await gpt_fix.run(user_request)
     try:
-        if not validate_impl_markdown(fixed_code, meta.filename):
+        if not b.validate_markdown(fixed_code, 'impl', meta.filename):
             if debug:
                 print(f'''[Fix implementation] Invalid doc:
 {fixed_code}''')
@@ -943,40 +584,18 @@ async def correct_test(meta: MarshaMeta, code: str, tests: str, results: str, re
     # The "punt back": the only path that may edit the oracle, and only spec-anchored. It must
     # justify every change by the assignment and must never weaken a test that is actually
     # correct (so a misrouted diagnosis degrades to a no-op rather than a bent test).
-    gpt_fix = get_mapper(f'''You are a senior software engineer correcting a faulty unit test.
-You are given the assignment, the implementation, the unit test suite, and the test results.
-A diagnosis has determined that a TEST (not the implementation) is at fault: it asserts behavior the assignment does not actually require — for example it is over-strict, it contradicts the assignment, it tests an implementation detail, or it pins down an exact error-message wording or output format that the assignment leaves open.
-Correct ONLY the faulty test(s) so that the test suite faithfully tests the assignment. Every change you make must be justified by the assignment: reference the part of the assignment that makes the current test wrong.
-You must NOT weaken a test that is actually correct: if a failing assertion is genuinely required by the assignment, leave that test unchanged.
-You must NOT modify the implementation, and you must not write new tests beyond correcting the faulty ones.
-Your response must not comment on what you changed.
-Your response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.
-Your response must be a markdown file.
-The first section header must be the filename `{meta.filename}_test.py`.
-The content of the first section must be a python code block with the corrected test code.
-The file should end with the code block, nothing else should be added to the file.
-The desired response must look like the following:
-
-# {meta.filename}_test.py
-
-```py
-<corrected code>
-```
-
-''', model=resolve_strong_model(), stats_stage='third_stage', label='test-correct')
+    b = backends.current()
+    gpt_fix = get_mapper(b.correct_test_prompt(meta), model=resolve_strong_model(),
+                         stats_stage='third_stage', label='test-correct')
     user_request = f'''{format_marsha_for_llm(meta)}
 
-# {meta.filename}.py
+# {b.source_name(meta.filename)}
 
-```py
-{code}
-```
+{b.code_block(code)}
 
-# {meta.filename}_test.py
+# {b.test_name(meta.filename)}
 
-```py
-{tests}
-```
+{b.code_block(tests)}
 
 # Test Results
 
@@ -987,7 +606,7 @@ The desired response must look like the following:
 A test is at fault: {reason}'''
     fixed_test = await gpt_fix.run(user_request)
     try:
-        if not validate_second_stage_markdown(fixed_test, f'{meta.filename}_test.py'):
+        if not b.validate_markdown(fixed_test, 'oracle', meta.filename):
             if debug:
                 print(f'''[Correct test] Invalid doc:
 {fixed_test}''')
@@ -1007,25 +626,20 @@ def _code_from_test_md(md: str) -> str:
 
 
 def _correction_review_message(meta, code, orig_test, corrected_code, reason):
+    b = backends.current()
     return f'''{format_marsha_for_llm(meta)}
 
-# {meta.filename}.py
+# {b.source_name(meta.filename)}
 
-```py
-{code}
-```
+{b.code_block(code)}
 
 # Original test suite
 
-```py
-{orig_test}
-```
+{b.code_block(orig_test)}
 
 # Corrected test suite
 
-```py
-{corrected_code}
-```
+{b.code_block(corrected_code)}
 
 # Diagnosis
 
@@ -1061,7 +675,8 @@ async def validate_test_correction(meta: MarshaMeta, code: str, orig_test: str, 
             meta, code, orig_test, corrected_code, reason)
         if i > 0:
             user_message += prior_round_block(prior_findings, prior_preamble)
-        findings = await run_personas(reviewers, user_message, model, 'third_stage', debug, loop='correction')
+        findings = await run_personas(reviewers, user_message, model, 'third_stage', debug,
+                                      loop='correction', guidance=backends.current().persona_guidance())
         actionable = actionable_findings(findings, severities)
         if not actionable:
             if debug:
@@ -1099,14 +714,15 @@ async def validate_test_correction(meta: MarshaMeta, code: str, orig_test: str, 
 async def test_and_fix_files(meta: MarshaMeta, files: list[str], retries: int = 4, debug: bool = False, args=None):
     if retries == 0:
         raise Exception('Failed to fix code', meta.filename)
+    b = backends.current()
     # There should only be two files, the test file and the code file
     test_file = [file for file in files if file.endswith(
-        f'{meta.filename}_test.py')][0]
+        b.test_name(meta.filename))][0]
     code_file = [file for file in files if file.endswith(
-        f'{meta.filename}.py')][0]
-    req_files = [file for file in files if file.endswith('requirements.txt')]
+        b.source_name(meta.filename))][0]
+    req_files = [file for file in files if file.endswith(b.manifest_name())]
     req_file = req_files[0] if len(req_files) > 0 else None
-    passed, test_results = await run_test_suite(code_file, test_file, req_file, debug)
+    passed, test_results = await b.run_tests(code_file, test_file, req_file, debug)
     if passed is None:  # If the test suite failed to run, we try again
         log('test suite failed to run; retrying')
         return await test_and_fix_files(meta, files, retries - 1, debug, args)
@@ -1144,11 +760,12 @@ async def test_and_fix_files(meta: MarshaMeta, files: list[str], retries: int = 
         return await test_and_fix_files(meta, files, retries - 1, debug, args)
 
 
-async def generate_python_code(args, meta: MarshaMeta, n_results: int, debug: bool) -> list[str]:
+async def generate_code(args, meta: MarshaMeta, n_results: int, debug: bool) -> list[tuple[str, str]]:
     t1 = time.time()
-    print('Generating Python code...')
+    b = backends.current()
+    print(f'Generating {b.id} code...')
     log(f'first stage: {meta.filename} (n={n_results})')
-    mds = None
+    cands = None
     try:
         if not args.exclude_sanity_check:
             log('spec sanity check')
@@ -1161,8 +778,9 @@ async def generate_python_code(args, meta: MarshaMeta, n_results: int, debug: bo
             if not check['compilable']:
                 sys.exit(1)
         # Oracle-first: generate the spec-anchored test suite, then generate implementations
-        # against it. Each candidate keeps the standard (code, requirements, test) shape, but the
-        # test section is the shared oracle, so the implementation is written to a fixed oracle.
+        # against it. Each candidate is (impl, oracle); the oracle is the single canonical string
+        # every impl is written against, and the backend composes them into the on-disk layout
+        # at write time, so the impl path can never touch the oracle.
         oracle = await gpt_test_suite(meta, debug=debug)
         log(f'oracle test suite generated ({len(oracle)} chars)')
         if args.optimize > 0 and not args.quick_and_dirty:
@@ -1171,12 +789,8 @@ async def generate_python_code(args, meta: MarshaMeta, n_results: int, debug: bo
             oracle = await optimize_test_suite(meta, oracle, args, debug)
         log(f'generating {n_results} implementation(s)')
         impls = await gpt_implementation(meta, oracle, n_results, debug=debug)
-        mds = []
-        for impl in impls:
-            doc = impl + '\n\n' + oracle
-            if validate_first_stage_markdown(doc, meta.filename):
-                mds.append(doc)
-        if len(mds) == 0:
+        cands = [(impl, oracle) for impl in impls]
+        if len(cands) == 0:
             raise Exception('No valid implementation candidates')
     except Exception as e:
         print('First stage failure')
@@ -1189,7 +803,7 @@ async def generate_python_code(args, meta: MarshaMeta, n_results: int, debug: bo
         t2 = time.time()
         stats.first_stage.total_time = prettify_time_delta(
             t2 - t1)
-    return mds
+    return cands
 
 
 async def review_and_fix(args, meta: MarshaMeta, files: list[str], debug: bool = False):
@@ -1231,7 +845,7 @@ async def review_and_fix(args, meta: MarshaMeta, files: list[str], debug: bool =
             print(f'# {file}\n{read_file(file)}\n')
     print('Formatting code...')
     log('formatting')
-    autoformat_files(files)
+    backends.current().format_files(files)
     if debug:
         for file in files:
             print(f'# {file}\n{read_file(file)}\n')

--- a/marsha/meta.py
+++ b/marsha/meta.py
@@ -197,6 +197,24 @@ def extract_type_filename(md):
     return header.split(' ')[2]
 
 
+def extract_func_name(type) -> str:
+    ast = ast_renderer.get_ast(Document(type))
+    if ast['children'][0]['type'] != 'Heading':
+        raise Exception('Invalid Marsha function')
+    header = ast['children'][0]['children'][0]['content']
+    return header.split('(')[0].split('func')[1].strip()
+
+
+def void_note(meta: MarshaMeta) -> str:
+    # The note telling oracle-related prompts not to test the void functions (grammar-level,
+    # target-language-agnostic). Empty when the assignment has no void functions.
+    void_function_names = list(
+        map(lambda f: extract_func_name(f), meta.void_funcs))
+    if len(void_function_names) == 0:
+        return ''
+    return f'Do not create any tests for the void functions: {", ".join(void_function_names)}.'
+
+
 class MarshaMeta():
     def __init__(self, input_file):
         self.input_file = input_file

--- a/marsha/parse.py
+++ b/marsha/parse.py
@@ -87,80 +87,6 @@ def format_marsha_for_llm(meta: MarshaMeta):
     return break_line.join(res)
 
 
-# TODO: Potentially re-org this so the stages are together?
-def validate_first_stage_markdown(md, marsha_filename):
-    ast = ast_renderer.get_ast(Document(md))
-    if len(ast['children']) != 4 and len(ast['children']) != 6:
-        return False
-    if len(ast['children']) == 4:
-        if ast['children'][0]['type'] != 'Heading':
-            return False
-        if ast['children'][2]['type'] != 'Heading':
-            return False
-        if ast['children'][1]['type'] != 'CodeFence':
-            return False
-        if ast['children'][3]['type'] != 'CodeFence':
-            return False
-        if ast['children'][0]['children'][0]['content'].strip() != f'{marsha_filename}.py':
-            return False
-        if ast['children'][2]['children'][0]['content'].strip() != f'{marsha_filename}_test.py':
-            return False
-    else:
-        if ast['children'][0]['type'] != 'Heading':
-            return False
-        if ast['children'][2]['type'] != 'Heading':
-            return False
-        if ast['children'][4]['type'] != 'Heading':
-            return False
-        if ast['children'][1]['type'] != 'CodeFence':
-            return False
-        if ast['children'][3]['type'] != 'CodeFence':
-            return False
-        if ast['children'][5]['type'] != 'CodeFence':
-            return False
-        if ast['children'][0]['children'][0]['content'].strip() != f'{marsha_filename}.py':
-            return False
-        if ast['children'][2]['children'][0]['content'].strip() != 'requirements.txt':
-            return False
-        if ast['children'][4]['children'][0]['content'].strip() != f'{marsha_filename}_test.py':
-            return False
-    return True
-
-
-def validate_impl_markdown(md, marsha_filename):
-    # An implementation-only document: the code file, optionally followed by requirements.txt
-    ast = ast_renderer.get_ast(Document(md))
-    if len(ast['children']) != 2 and len(ast['children']) != 4:
-        return False
-    if ast['children'][0]['type'] != 'Heading':
-        return False
-    if ast['children'][1]['type'] != 'CodeFence':
-        return False
-    if ast['children'][0]['children'][0]['content'].strip() != f'{marsha_filename}.py':
-        return False
-    if len(ast['children']) == 4:
-        if ast['children'][2]['type'] != 'Heading':
-            return False
-        if ast['children'][3]['type'] != 'CodeFence':
-            return False
-        if ast['children'][2]['children'][0]['content'].strip() != 'requirements.txt':
-            return False
-    return True
-
-
-def validate_second_stage_markdown(md, filename):
-    ast = ast_renderer.get_ast(Document(md))
-    if len(ast['children']) != 2:
-        return False
-    if ast['children'][0]['type'] != 'Heading':
-        return False
-    if ast['children'][1]['type'] != 'CodeFence':
-        return False
-    if ast['children'][0]['children'][0]['content'].strip() != filename:
-        return False
-    return True
-
-
 def write_files_from_markdown(md: str, subdir=None) -> list[str]:
     ast = ast_renderer.get_ast(Document(md))
     filenames = []
@@ -182,11 +108,3 @@ def write_files_from_markdown(md: str, subdir=None) -> list[str]:
                 os.makedirs(os.path.dirname(filename), exist_ok=True)
             write_file(filename, filedata)
     return filenames
-
-
-def extract_func_name(type) -> str:
-    ast = ast_renderer.get_ast(Document(type))
-    if ast['children'][0]['type'] != 'Heading':
-        raise Exception('Invalid Marsha function')
-    header = ast['children'][0]['children'][0]['content']
-    return header.split('(')[0].split('func')[1].strip()

--- a/marsha/personas/README.md
+++ b/marsha/personas/README.md
@@ -29,6 +29,10 @@ The built-in registry is discovered by scanning this directory for `*.md` (exclu
 
 Each flag takes a comma-separated list. An entry is either a **built-in name** (e.g. `eli,max`) or a **path** to a custom file (detected by a leading `/`, `.`, or `~`, e.g. `./sharona.md`). Mixing is allowed: `--impl-personas eli,max,./sharona.md`. Omit a flag to run that loop's default set (all built-ins for the loop, name-sorted). A custom file must also start with `name: <name>`.
 
+## Language-specific conventions
+
+Reviewer bodies are deliberately language-agnostic ("an assignment", "an implementation") so one shared set serves every target language. Per-language and per-project conventions (for the Python backend: type hints, PEP8, autopep8, `requirements.txt`) are supplied by the target backend's `persona_guidance()` and injected into every reviewer run — the backend is selected with `--target` (see the top-level README).
+
 ## Finding labels
 
 Each finding is labeled `<letter><N>` — the letter is the finding's position (A, B, C, ...) and `N` is the reviewer's 1-based position in the resolved list. References use `[Name-Label]` (e.g. `[Ada-A1]`), so in a later round a reviewer can recognize its own label in the implementor's push-back.

--- a/marsha/personas/__init__.py
+++ b/marsha/personas/__init__.py
@@ -255,13 +255,17 @@ def prior_round_block(findings, preamble):
     return block
 
 
-async def run_personas(reviewers, user_message, model, stats_stage, debug=False, loop=None):
+async def run_personas(reviewers, user_message, model, stats_stage, debug=False, loop=None, guidance=''):
     # Run every reviewer independently; return the flattened labeled findings. On a local
     # (serial) backend the reviewers run one at a time so each gets the whole server; otherwise
-    # they run concurrently.
+    # they run concurrently. `guidance` is the target-language backend's persona_guidance(): the
+    # per-language conventions the (language-agnostic) reviewer bodies leave out.
     async def one(spec):
         name, body, review_number = spec
-        system = body + FINDINGS_CONTRACT.format(review_number=review_number)
+        system = body
+        if guidance:
+            system += f'\n\n{guidance}'
+        system += FINDINGS_CONTRACT.format(review_number=review_number)
         label = f'{loop}:{name}' if loop else name
         try:
             mapper = get_mapper(

--- a/marsha/personas/impl-anti-overfit.md
+++ b/marsha/personas/impl-anti-overfit.md
@@ -1,5 +1,5 @@
 name: Otto
-You are Otto, a generalization reviewer for a Python 3 implementation judged against a unit-test oracle. The oracle is a *sample*, not the spec.
+You are Otto, a generalization reviewer for an implementation judged against a unit-test oracle. The oracle is a *sample*, not the spec.
 Goal: the code is genuinely general, not bent to pass the particular tests.
 Check:
 - Special-casing the oracle's exact example inputs (e.g., `if input == example: return expected`).

--- a/marsha/personas/impl-completeness.md
+++ b/marsha/personas/impl-completeness.md
@@ -1,5 +1,5 @@
 name: Eli
-You are Eli, a completeness-focused software engineer reviewing a Python 3 implementation against its assignment.
+You are Eli, a completeness-focused software engineer reviewing an implementation against its assignment.
 Goal: every function and behavior the assignment requires is actually implemented; nothing is dropped, stubbed, or left as a TODO.
 Check:
 - Required functions or branches that are missing or silently stubbed.

--- a/marsha/personas/impl-correctness.md
+++ b/marsha/personas/impl-correctness.md
@@ -1,5 +1,5 @@
 name: Sage
-You are Sage, a correctness-focused software engineer reviewing a Python 3 implementation against its assignment.
+You are Sage, a correctness-focused software engineer reviewing an implementation against its assignment.
 Goal: the code computes exactly what the assignment says, beyond what the current tests pin down.
 Check:
 - Off-by-one errors, wrong operators, or misread rules.

--- a/marsha/personas/impl-deps.md
+++ b/marsha/personas/impl-deps.md
@@ -1,7 +1,7 @@
 name: Dot
-You are Dot, a dependency-hygiene reviewer for a Python 3 implementation and its requirements.txt.
-Goal: requirements.txt is minimal, correct, and consistent with the code.
+You are Dot, a dependency-hygiene reviewer for an implementation and its dependency manifest.
+Goal: the dependency manifest is minimal, correct, and consistent with the code.
 Check:
 - Missing dependencies the code imports; unused dependencies.
 - Pinned versions (dependencies must not be pinned).
-- Standard-library modules listed as dependencies.
+- Standard-library (already available) modules listed as dependencies.

--- a/marsha/personas/impl-error-contract.md
+++ b/marsha/personas/impl-error-contract.md
@@ -1,7 +1,7 @@
 name: Ezra
-You are Ezra, an error-handling reviewer for a Python 3 implementation.
+You are Ezra, an error-handling reviewer for an implementation.
 Goal: where the assignment calls for errors, the right error is raised at the right time; nowhere else are errors invented.
 Check:
-- Missing or wrong exceptions where the spec requires them.
-- Swallowed exceptions, bare `except`, or `except: pass`.
+- Missing or wrong errors/exceptions where the spec requires them.
+- Swallowed or ignored errors (empty catch blocks).
 - Over-broad catches that hide real faults, or invented errors the spec never asks for.

--- a/marsha/personas/impl-perf-algorithmic.md
+++ b/marsha/personas/impl-perf-algorithmic.md
@@ -1,5 +1,5 @@
 name: Max
-You are Max, an algorithms engineer reviewing a Python 3 implementation's complexity.
+You are Max, an algorithms engineer reviewing an implementation's complexity.
 Goal: the algorithmic complexity and hot path are sound.
 Check:
 - Accidental quadratic (or worse) complexity where the spec implies larger inputs.

--- a/marsha/personas/impl-perf-architectural.md
+++ b/marsha/personas/impl-perf-architectural.md
@@ -1,5 +1,5 @@
 name: Ari
-You are Ari, a systems architect reviewing the *design* of a Python 3 implementation for performance.
+You are Ari, a systems architect reviewing the *design* of an implementation for performance.
 Goal: the overall approach is efficient for the problem's real size.
 Check:
 - The wrong data structures for the task (e.g., a list where a set or dict is natural).

--- a/marsha/personas/impl-perf-micro.md
+++ b/marsha/personas/impl-perf-micro.md
@@ -1,7 +1,7 @@
 name: Mik
-You are Mik, a micro-optimization reviewer for a Python 3 implementation. Keep every suggestion cheap and readability-safe.
+You are Mik, a micro-optimization reviewer for an implementation. Keep every suggestion cheap and readability-safe.
 Goal: small local efficiency wins that never hurt clarity.
 Check:
-- Hand-rolled loops where a builtin or comprehension is clearer and faster.
+- Hand-rolled loops where a builtin or an idiomatic language construct is clearer and faster.
 - Recomputed constants or repeated attribute lookups in a loop.
 Flag only clear, safe wins; prefer doing nothing over a clever-but-obscure tweak.

--- a/marsha/personas/impl-readability.md
+++ b/marsha/personas/impl-readability.md
@@ -1,7 +1,7 @@
 name: Lena
-You are Lena, a code-quality reviewer focused on the readability and structure of a Python 3 implementation.
+You are Lena, a code-quality reviewer focused on the readability and structure of an implementation.
 Goal: a stranger can read the code and see that it does what the assignment says.
 Check:
 - Unclear or misleading names; a god-function that should be decomposed.
-- Dead code; PEP8 violations.
-- Missing or inaccurate type hints; a docstring that does not match the function or the spec.
+- Dead code; style-guide violations.
+- Missing or inaccurate type annotations; documentation that does not match the function or the spec.

--- a/marsha/personas/impl-safety-adversarial.md
+++ b/marsha/personas/impl-safety-adversarial.md
@@ -1,7 +1,7 @@
 name: Sasha
-You are Sasha, a security and robustness engineer reviewing a Python 3 implementation for resistance to bad and adversarial input.
+You are Sasha, a security and robustness engineer reviewing an implementation for resistance to bad and adversarial input.
 Goal: the code behaves sensibly on bad, malformed, or adversarial input.
 Check:
 - Crashes on plausible bad input where the assignment implies it should be handled.
 - Unbounded memory, recursion depth, or CPU on pathological input.
-- Dangerous constructs: eval/exec, pickle, shell injection, path traversal, or mishandled secrets.
+- Dangerous constructs: unsafe deserialization, code injection, shell injection, path traversal, or mishandled secrets.

--- a/marsha/personas/impl-terseness.md
+++ b/marsha/personas/impl-terseness.md
@@ -1,5 +1,5 @@
 name: Kit
-You are Kit, a terseness reviewer for a Python 3 implementation. You remove waste, not clarity.
+You are Kit, a terseness reviewer for an implementation. You remove waste, not clarity.
 Goal: the code is minimal - no over-explanatory comments, no dead weight, no speculative generality.
 Check:
 - Comments that merely restate the code they sit next to.

--- a/marsha/personas/oracle-completeness.md
+++ b/marsha/personas/oracle-completeness.md
@@ -1,5 +1,5 @@
 name: Ada
-You are Ada, a meticulous QA engineer auditing a unit test suite (the oracle) for a Python 3 assignment. The test suite is the authoritative oracle used to judge generated implementations, so it must be complete and trustworthy.
+You are Ada, a meticulous QA engineer auditing a unit test suite (the oracle) for an assignment. The test suite is the authoritative oracle used to judge generated implementations, so it must be complete and trustworthy.
 Goal: every piece of *testable* behavior the assignment states is covered by at least one test.
 Check:
 - Each worked example the assignment provides.

--- a/marsha/personas/oracle-edge-bounds.md
+++ b/marsha/personas/oracle-edge-bounds.md
@@ -1,5 +1,5 @@
 name: Bram
-You are Bram, a boundary-hunting QA engineer auditing a unit test suite (the oracle) for a Python 3 assignment.
+You are Bram, a boundary-hunting QA engineer auditing a unit test suite (the oracle) for an assignment.
 Goal: the suite probes the boundaries the assignment *implies*, without inventing new requirements.
 Check:
 - Boundaries the assignment's own examples or wording gesture at: empty, single-element, maximum, minimum, zero, negative, very large, unicode, or malformed/whitespace variants.

--- a/marsha/personas/oracle-failure-clarity.md
+++ b/marsha/personas/oracle-failure-clarity.md
@@ -1,5 +1,5 @@
 name: Clara
-You are Clara, a diagnosability-focused QA engineer auditing a unit test suite (the oracle) for a Python 3 assignment.
+You are Clara, a diagnosability-focused QA engineer auditing a unit test suite (the oracle) for an assignment.
 Goal: when a test fails, the failure localizes the real cause.
 Check:
 - Overly coarse assertions (one giant comparison of an entire structure where a targeted check would pinpoint the fault).

--- a/marsha/personas/oracle-fidelity.md
+++ b/marsha/personas/oracle-fidelity.md
@@ -1,5 +1,5 @@
 name: Vera
-You are Vera, a rigorous QA engineer auditing a unit test suite (the oracle) for a Python 3 assignment. The oracle must be faithful to the assignment: it must not assert anything the assignment never promised.
+You are Vera, a rigorous QA engineer auditing a unit test suite (the oracle) for an assignment. The oracle must be faithful to the assignment: it must not assert anything the assignment never promised.
 Goal: no test asserts behavior the assignment does not state.
 Check:
 - Tests that invent inputs or expected outputs the assignment does not ground.

--- a/marsha/personas/oracle-hermeticity.md
+++ b/marsha/personas/oracle-hermeticity.md
@@ -1,5 +1,5 @@
 name: Dora
-You are Dora, a hermeticity-focused QA engineer auditing a unit test suite (the oracle) for a Python 3 assignment. The oracle is the guardrail, so it must be fully deterministic.
+You are Dora, a hermeticity-focused QA engineer auditing a unit test suite (the oracle) for an assignment. The oracle is the guardrail, so it must be fully deterministic.
 Goal: the suite is deterministic and hermetic on every run.
 Check:
 - Dependence on the network, the file system, the clock or time, randomness, the current working directory, or environment variables.

--- a/marsha/personas/oracle-independence.md
+++ b/marsha/personas/oracle-independence.md
@@ -1,5 +1,5 @@
 name: Uma
-You are Uma, a test-structure QA engineer auditing a unit test suite (the oracle) for a Python 3 assignment.
+You are Uma, a test-structure QA engineer auditing a unit test suite (the oracle) for an assignment.
 Goal: the tests are independent, order-independent, and non-redundant.
 Check:
 - Shared mutable state or fixtures that leak between tests.

--- a/marsha/personas/oracle-transcription.md
+++ b/marsha/personas/oracle-transcription.md
@@ -1,5 +1,5 @@
 name: Tessa
-You are Tessa, a precise QA engineer auditing a unit test suite (the oracle) for a Python 3 assignment.
+You are Tessa, a precise QA engineer auditing a unit test suite (the oracle) for an assignment.
 Goal: every worked example in the assignment is transcribed into a test exactly.
 Check:
 - Each example's input is copied faithfully into the test.

--- a/marsha/utils.py
+++ b/marsha/utils.py
@@ -1,5 +1,5 @@
-from inspect import getsourcefile
-import autopep8
+import asyncio
+from asyncio.subprocess import Process
 import os
 import shutil
 
@@ -39,11 +39,16 @@ def write_file(filename: str, content: str, mode: str = 'w'):
         f.write(content)
 
 
-def autoformat_files(files: list[str]):
-    for file in files:
-        before = read_file(file)
-        after = autopep8.fix_code(before)
-        write_file(file, after)
+def write_composed(files: dict, subdir: str = None) -> list[str]:
+    # Write a composed on-disk layout ({path: content}) and return the written paths.
+    paths = []
+    for name, content in files.items():
+        path = f'{subdir}/{name}' if subdir is not None else name
+        if subdir is not None:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+        write_file(path, content)
+        paths.append(path)
+    return paths
 
 
 def copy_file(src: str, dest: str):
@@ -58,8 +63,18 @@ def get_filename_from_path(path: str):
     return os.path.splitext(os.path.basename(path))[0]
 
 
-def add_helper(filename: str):
-    helper = os.path.join(os.path.dirname(
-        os.path.abspath(getsourcefile(lambda: 0))), 'helper.py')
-    with open(filename, 'a') as o, open(helper, 'r') as i:
-        o.write(i.read())
+async def run_subprocess(stream: Process, timeout: float = 60.0) -> tuple[str, str]:
+    stdout = ''
+    stderr = ''
+    try:
+        stdout, stderr = await asyncio.wait_for(stream.communicate(), timeout)
+    except asyncio.exceptions.TimeoutError:
+        try:
+            stream.kill()
+        except OSError:
+            # Ignore 'no such process' error
+            pass
+        raise Exception('run_subprocess timeout...')
+    except Exception as e:
+        raise e
+    return (stdout.decode('utf-8'), stderr.decode('utf-8'))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
     { name = "Alan Technologies Maintainers", email = "hello@alantechnologies.com" },
 ]
 license = { text = "MIT" }
-requires-python = ">=3.10"
+requires-python = ">=3.14"
 dependencies = [
     "anthropic",
     "autopep8",
@@ -27,7 +27,7 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.14",
 ]
 urls = { repository = "https://github.com/alantech/marsha" }
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,0 +1,258 @@
+"""Regression tests for the Python language backend (issue #204).
+
+The refactor must be behavior-preserving for Python: these tests pin PythonBackend's
+naming, artifact contract, compose layout, markdown validators, and prompt templates
+to the pre-refactor hardcoded values, and exercise the toolchain leaves (helper append,
+toolchain detection, test execution) against the real Python toolchain.
+"""
+
+import asyncio
+from unittest.mock import patch
+
+from marsha import backends
+from marsha.backends import PythonBackend
+from marsha.meta import MarshaMeta
+from marsha.utils import read_file, write_file
+
+
+def make_meta(filename='example', void_funcs=()):
+    meta = MarshaMeta(f'{filename}.mrsh')
+    meta.filename = filename
+    meta.functions = []
+    meta.void_funcs = list(void_funcs)
+    meta.types = None
+    return meta
+
+
+# --- registry / --target resolution ------------------------------------------
+
+def test_registry_resolves_python_by_id_and_alias():
+    assert backends.resolve_target('python').id == 'python'
+    assert backends.resolve_target('py').id == 'python'
+    assert backends.resolve_target('PY').id == 'python'
+    assert backends.current().id == 'python'
+
+
+def test_registry_rejects_unknown_target():
+    try:
+        backends.resolve_target('rust')
+        assert False, 'expected an exception'
+    except Exception as e:
+        assert 'python' in str(e)
+
+
+# --- naming / contract ---------------------------------------------------------
+
+def test_naming():
+    b = PythonBackend()
+    assert b.id == 'python'
+    assert 'py' in b.aliases
+    assert b.code_fence_lang == 'py'
+    assert b.source_name('example') == 'example.py'
+    assert b.test_name('example') == 'example_test.py'
+    assert b.manifest_name() == 'requirements.txt'
+
+
+def test_artifact_contract():
+    b = PythonBackend()
+    assert b.artifact_contract('example') == [
+        ('source', 'example.py'),
+        ('manifest', 'requirements.txt'),
+        ('test', 'example_test.py'),
+    ]
+
+
+def test_code_block():
+    assert PythonBackend().code_block('x') == '```py\nx\n```'
+
+
+# --- compose layout -------------------------------------------------------------
+
+def test_compose_with_manifest():
+    b = PythonBackend()
+    impl = ('# example.py\n\n```py\ncode\n```\n\n'
+            '# requirements.txt\n\n```txt\nnumpy\n```\n')
+    oracle = '# example_test.py\n\n```py\ntests\n```\n'
+    # Code-fence content is taken verbatim (including the trailing newline), exactly as
+    # write_files_from_markdown used to write it.
+    composed = b.compose(impl, oracle)
+    assert composed == {
+        'example.py': 'code\n',
+        'requirements.txt': 'numpy\n',
+        'example_test.py': 'tests\n',
+    }
+    # The source file comes first, then the manifest, then the oracle.
+    assert list(composed) == ['example.py', 'requirements.txt', 'example_test.py']
+
+
+def test_compose_without_manifest():
+    b = PythonBackend()
+    impl = '# example.py\n\n```py\ncode\n```\n'
+    oracle = '# example_test.py\n\n```py\ntests\n```\n'
+    assert list(b.compose(impl, oracle)) == ['example.py', 'example_test.py']
+
+
+def test_compose_skips_empty_fences():
+    b = PythonBackend()
+    impl = ('# example.py\n\n```py\ncode\n```\n\n'
+            '# requirements.txt\n\n```txt\n```\n')
+    oracle = '# example_test.py\n\n```py\ntests\n```\n'
+    assert 'requirements.txt' not in b.compose(impl, oracle)
+
+
+# --- validators -----------------------------------------------------------------
+
+def test_validate_impl():
+    b = PythonBackend()
+    ok = '# example.py\n\n```py\nx\n```\n'
+    ok_manifest = ok + '\n# requirements.txt\n\n```txt\ny\n```\n'
+    assert b.validate_markdown(ok, 'impl', 'example')
+    assert b.validate_markdown(ok_manifest, 'impl', 'example')
+    assert not b.validate_markdown(ok, 'impl', 'other')
+    assert not b.validate_markdown(
+        ok + '\n# other.txt\n\n```txt\ny\n```\n', 'impl', 'example')
+    assert not b.validate_markdown('# example.py\n', 'impl', 'example')
+
+
+def test_validate_oracle():
+    b = PythonBackend()
+    ok = '# example_test.py\n\n```py\nx\n```\n'
+    assert b.validate_markdown(ok, 'oracle', 'example')
+    assert not b.validate_markdown(ok, 'oracle', 'other')
+    assert not b.validate_markdown('# example.py\n\n```py\nx\n```\n', 'oracle', 'example')
+
+
+def test_validate_unit_uses_verbatim_name():
+    b = PythonBackend()
+    full = '# /tmp/x/example.py\n\n```py\nx\n```\n'
+    assert b.validate_markdown(full, 'unit', '/tmp/x/example.py')
+    assert not b.validate_markdown(full, 'unit', 'example.py')
+    assert not b.validate_markdown(
+        full + '\n# more.py\n\n```py\ny\n```\n', 'unit', '/tmp/x/example.py')
+
+
+def test_validate_unknown_kind_is_false():
+    assert not PythonBackend().validate_markdown('# a\n\n```py\nx\n```\n', 'bogus', 'a')
+
+
+# --- prompt templates (byte-exact anchors) ----------------------------------------
+
+FN = "example"
+
+LINT_FILENAME = "/tmp/pytest-x/example.py"
+
+
+SPEC_CHECK = 'You are a senior software engineer reviewing an assignment to write a Python 3 function.\nThe assignment is written in markdown format.\nIt should include sections on the function name, inputs, outputs, a description of what it should do, and some examples of how it should be used.\n\nFirst, decide whether the document is compilable. Use this test: could at least one implementation exist that satisfies every part of the document (description, inputs, outputs, and all examples) at the same time? If such an implementation could exist, the document is compilable.\nUnderspecification is not a reason the document is not compilable: like unspecified behavior in C, whatever the document leaves open is for the implementer to decide reasonably. If the description allows several outcomes (several valid orderings, several equivalent error messages, several formats) and the examples show one of them, an implementation that follows the examples satisfies the document, so it is compilable.\nOne section adding more detail than another is not a contradiction: sections only conflict when they state opposing views on what the code should be doing.\nThe document is not compilable only when no implementation could satisfy it as written, eg the description says the function prints its result while the examples compare its return value to a string, two examples give different outputs for the same input, or an example is malformed or violates a stated requirement.\n\nSecond, list warnings for significant ambiguities. A warning is for an underspecified or ambiguous area that could result in differently-behaving code between independent generation runs, eg a missing exception type or message, missing edge cases, an ambiguous output precision or format, or non-deterministic behavior that would make the generated code flaky to test.\nBe careful not to wear out the user with useless warnings: only warn when the ambiguity is significant enough that two reasonable implementers could plausibly produce different behavior. Do not warn about style, and do not ask for more examples or more precision in areas that are merely unspecified but unlikely to change the behavior.\n\nRespond with a single JSON object and nothing else, in exactly this shape:\n{"compilable": true, "warnings": ["...", "..."]}\nWhen the document is not compilable, include a third key, an "errors" array with one or more entries:\n{"compilable": false, "warnings": ["..."], "errors": ["...", "..."]}\nEach warning and each error is a markdown-formatted string that cites the relevant portion of the document using inline quotes of the document\'s own words. Each error must quote the sections that conflict with each other and explain why no implementation could satisfy both.\nDo not wrap the JSON object in code fences.\n'
+
+
+DIAGNOSE = 'You are a senior software engineer debugging a Python 3 project.\nYou are given the assignment (in markdown), the implementation, the unit test suite (the oracle), and the unit test results.\nThe test suite was derived from the assignment and is authoritative for what the code should do, except where a test is itself wrong.\nDetermine the root cause of the failure:\n- "implementation": the code is at fault — it does not correctly implement the assignment (a bug, a missing edge case, wrong logic, a missing or wrong import, etc.).\n- "test": a test is at fault — it asserts behavior the assignment does not actually require (it is over-strict, it contradicts the assignment, it tests an implementation detail, or it pins down an exact error-message wording or output format that the assignment leaves open).\nChoose "test" only when the failing assertion is genuinely not required by the assignment; when in doubt, choose "implementation".\nRespond with a single JSON object and nothing else, in exactly this shape:\n{"fault": "implementation", "reason": "..."}\nor\n{"fault": "test", "reason": "..."}\nDo not wrap the JSON object in code fences.\n'
+
+
+ORACLE = 'You are a senior software engineer assigned to write a unit test suite for Python 3 functions.\nThe assignment is written in markdown format.\nThe test suite is the *oracle* used to judge generated implementations, so it must be trustworthy.\nThe unit tests created should exactly match the example cases provided for each function.\nYou have to create a TestCase per function provided.\n\nThe filename should exactly match the name `example_test.py`.\nUnknown imports might come from the file where the function is defined, or from the standard library.\nIf you are working with files, make sure to mock the file system since the tests will be run in a sandboxed environment.\nMake sure to follow PEP8 guidelines.\nMake sure to include all needed standard Python libraries imports.\nThe tests must be faithful to the assignment:\n- Every test must correspond to an example of expected behavior in the assignment, or to behavior its description explicitly states.\n- Do not assert behavior the assignment does not state. Do not test implementation details, internal structure, or the exact wording of error messages or output formats unless the assignment pins them down.\n- Do not invent edge cases, inputs, or expected outputs that are not grounded in the assignment.\nYour response must not comment on what you changed.\nYour response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.\nYour response must be a markdown file.\nThe first section header must be the filename `example_test.py`.\nThe content of the first section must be a python code block with the generated code.\nThe file should end with the code block, nothing else should be added to the file.\nThe desired response must look like the following:\n\n# example_test.py\n\n```py\n<generated code>\n```\n\n'
+
+
+IMPL = 'You are a senior software engineer assigned to write Python 3 functions.\nThe assignment is written in markdown format.\nThe description of each function should be included as a docstring.\nAdd type hints if feasible.\nThe filename should exactly match the name `example.py`.\nMake sure to follow PEP8 guidelines.\nMake sure to include all needed standard Python libraries imports.\nGenerate `requirements.txt` file with all needed dependencies, do not add fixed version to dependencies.\nIf need to convert `type` to Python classes, you will receive a markdown where the heading is the class name followed by several rows following a comma separated CSV format where the first row contains all class properties and the following rows contain examples of the values of those properties. Make sure to add the __str__, __repr__, and __eq__ methods to the class.\nA unit test suite has already been written from this same assignment and is provided to you. Your implementation must satisfy the assignment AND pass this test suite. If anything in the test suite ever appears to conflict with the assignment, the assignment is authoritative.\nYour response must not comment on what you changed.\nYour response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.\nYour response must be a markdown file.\nThe first section header must be the filename `example.py`.\nThe content of the first section must be a python code block with the generated code.\nThe second section header must be the filename `requirements.txt`.\nThe content of the second section must be a text code block with the generated code.\nThe file should end with the code block, nothing else should be added to the file.\nThe desired response must look like the following:\n\n# example.py\n\n```py\n<generated code>\n```\n\n# requirements.txt\n\n```txt\n<dependencies needed>\n```\n\n'
+
+
+LINT_FIX = 'You are a senior software engineer working with Python 3.\nYou are using a Python linter to find obvious errors and then fixing them. The linter uses `pyflakes` and `pycodestyle` under the hood to provide the recommendations.\nAll of the lint errors require fixing.\nYou should only fix the lint errors and not change anything else.\nYour response must not comment on what you changed.\nYour response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.\nYour response must be a markdown file.\nThe first section header must be the filename `/tmp/pytest-x/example.py`.\nThe content of the first section must be a python code block with the generated code.\nThe file should end with the code block, nothing else should be added to the file.\nThe desired response must look like the following:\n\n# /tmp/pytest-x/example.py\n\n```py\n<fixed code>\n```\n\n'
+
+
+IMPL_FIX = 'You are a senior software engineer fixing a Python 3 implementation that is failing its unit tests.\nYou are given the assignment, the implementation, the unit test suite (the oracle), and the test results.\nThe unit test suite is authoritative and must NOT be modified.\nFix only the implementation so that it correctly implements the assignment and passes the test suite, making the least changes necessary.\nMake sure to produce working code that passes the unit tests.\nMake sure to follow PEP8 style guidelines.\nMake sure to include all needed standard Python libraries imports.\nGenerate `requirements.txt` file with all needed dependencies, do not add fixed version to dependencies.\nYour response must not comment on what you changed.\nYour response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.\nYour response must be a markdown file.\nThe first section header must be the filename `example.py`.\nThe content of the first section must be a python code block with the generated code.\nThe second section header must be the filename `requirements.txt`.\nThe content of the second section must be a text code block with the generated code.\nThe file should end with the code block, nothing else should be added to the file.\nThe desired response must look like the following:\n\n# example.py\n\n```py\n<fixed code>\n```\n\n# requirements.txt\n\n```txt\n<dependencies needed>\n```\n\n'
+
+
+TEST_CORRECT = 'You are a senior software engineer correcting a faulty unit test.\nYou are given the assignment, the implementation, the unit test suite, and the test results.\nA diagnosis has determined that a TEST (not the implementation) is at fault: it asserts behavior the assignment does not actually require — for example it is over-strict, it contradicts the assignment, it tests an implementation detail, or it pins down an exact error-message wording or output format that the assignment leaves open.\nCorrect ONLY the faulty test(s) so that the test suite faithfully tests the assignment. Every change you make must be justified by the assignment: reference the part of the assignment that makes the current test wrong.\nYou must NOT weaken a test that is actually correct: if a failing assertion is genuinely required by the assignment, leave that test unchanged.\nYou must NOT modify the implementation, and you must not write new tests beyond correcting the faulty ones.\nYour response must not comment on what you changed.\nYour response must not add any additional comments, clarifications, notes, information, explanations, details, examples or thoughts.\nYour response must be a markdown file.\nThe first section header must be the filename `example_test.py`.\nThe content of the first section must be a python code block with the corrected test code.\nThe file should end with the code block, nothing else should be added to the file.\nThe desired response must look like the following:\n\n# example_test.py\n\n```py\n<corrected code>\n```\n\n'
+
+
+def test_prompts_are_byte_exact():
+    b = PythonBackend()
+    meta = make_meta()
+    assert b.spec_check_prompt() == SPEC_CHECK
+    assert b.diagnose_prompt() == DIAGNOSE
+    assert b.oracle_prompt(meta) == ORACLE
+    assert b.impl_prompt(meta) == IMPL
+    assert b.fix_impl_prompt(meta) == IMPL_FIX
+    assert b.correct_test_prompt(meta) == TEST_CORRECT
+    assert b.lint_fix_prompt(LINT_FILENAME) == LINT_FIX
+
+
+def test_oracle_prompt_includes_void_note():
+    b = PythonBackend()
+    meta = make_meta(void_funcs=['# func print_thing(x: str)'])
+    assert ('Do not create any tests for the void functions: print_thing.'
+            in b.oracle_prompt(meta))
+
+
+# --- persona guidance -------------------------------------------------------------
+
+def test_persona_guidance_carries_python_conventions():
+    g = PythonBackend().persona_guidance()
+    for phrase in ('Python 3', 'type hints', 'PEP8', 'autopep8', 'requirements.txt'):
+        assert phrase in g
+
+
+def test_persona_guidance_injected_into_reviewer_prompt():
+    from marsha import personas
+
+    seen = {}
+
+    class CapturingMapper:
+        def __init__(self, system, **kwargs):
+            seen['system'] = system
+
+        async def run(self, req):
+            return 'NO FINDINGS'
+
+    async def go(guidance):
+        with patch.object(personas, 'get_mapper',
+                          new=lambda *a, **k: CapturingMapper(*a, **k)):
+            await personas.run_personas(
+                [('Ada', 'You are Ada.', 1)], 'msg', 'model', 'first_stage',
+                loop='oracle', guidance=guidance)
+
+    asyncio.run(go(PythonBackend().persona_guidance()))
+    assert 'You are Ada.' in seen['system']
+    assert 'Python 3' in seen['system']
+    # Without guidance the reviewer body is used verbatim (pre-refactor behavior).
+    asyncio.run(go(''))
+    assert seen['system'].startswith('You are Ada.')
+    assert 'Python 3' not in seen['system']
+
+
+# --- toolchain leaves ---------------------------------------------------------------
+
+def test_make_executable_appends_helper(tmp_path):
+    b = PythonBackend()
+    path = f'{tmp_path}/example.py'
+    write_file(path, 'def f():\n    return 1\n')
+    before = read_file(path)
+    b.make_executable(path)
+    after = read_file(path)
+    assert after.startswith(before)
+    assert "if __name__ == '__main__':" in after
+
+
+def test_toolchain():
+    b = PythonBackend()
+    assert b.toolchain() in ('python', 'python3')
+    assert b.toolchain_ok()
+
+
+def test_run_tests_pass_and_fail(tmp_path):
+    b = PythonBackend()
+    code = f'{tmp_path}/example.py'
+    write_file(code, 'def add(a, b):\n    return a + b\n')
+    header = ('import unittest\nfrom example import add\n\n'
+              'class TestAdd(unittest.TestCase):\n')
+
+    def write_test(name, expected):
+        body = (f'    def test_add(self):\n        self.assertEqual(add(1, 2), {expected})\n\n'
+                'if __name__ == "__main__":\n    unittest.main()\n')
+        write_file(f'{tmp_path}/{name}', header + body)
+
+    write_test('ok_test.py', 3)
+    write_test('bad_test.py', 4)
+    passed, _ = asyncio.run(b.run_tests(code, f'{tmp_path}/ok_test.py', None, False))
+    assert passed is True
+    passed, results = asyncio.run(b.run_tests(code, f'{tmp_path}/bad_test.py', None, False))
+    assert passed is False
+    assert 'AssertionError' in results or 'FAILED' in results


### PR DESCRIPTION
## Summary

Marsha hardcoded Python through the generation pipeline: prompts, test runner, linter, formatter, file naming, output validation, the runnable-`main` helper, and toolchain detection. This extracts those leaves into a `LanguageBackend` interface so the core becomes target-language-agnostic. **Behavior-preserving for Python**; Rust is a separate follow-on (#183).

## Changes

- **`marsha/backends/`** — new package: the `LanguageBackend` interface, a `PythonBackend` that reproduces current behavior exactly, and a registry with id/alias resolution.
- **`--target <lang>` CLI** — default `python`; only `python` is wired, but the registry + dispatch are ready for more.
- **Core decoupled** — `generate_python_code` → `generate_code` (returns `(impl, oracle)` pairs); the harness composes via `backend.compose()` on every write so the impl path can never touch the oracle in any layout. `add_helper` → `backend.make_executable()`; formatting/linting/test-run/validators/fence-language all delegate to the backend.
- **Personas** — reviewer bodies reworded to be language-agnostic; per-language conventions now come from `persona_guidance()`, injected into every reviewer run.
- **Supporting moves** — `void_note()` added to `meta.py` (grammar-level, shared by core and backend); `extract_func_name` moved from `parse.py` to `meta.py`.
- **`tests/test_backend.py`** — regression tests pinning `PythonBackend`'s naming, contract, compose layout, validators, and prompt templates to the pre-refactor hardcoded values (byte-exact anchors).
- **Python 3.14 floor** — `requires-python` bumped to `>=3.14` and all CI workflows moved from 3.10 to 3.14. The compiler core is headed for Rust, so the Python implementation is the prototyping vehicle; carrying oldest-interpreter compatibility isn't worth it.

## Verification

- Existing test suite (`test_context` / `test_optimize` / `test_personas`) passes **unchanged**.
- Prompt templates verified byte-identical to the pre-refactor values via AST-captured anchors embedded in the new test.
- Validators differentially tested against the original `parse.py` from git — all match.
- The optimize guardrail still runs the real test suite through `PythonBackend.run_tests`.
- Verified on both Python 3.14 (new floor: exact CI lint commands + full suite) and 3.10 (import + full suite, for the transition).
- Full suite: 75 passed; flake8 clean.

## Notes

- The only stdout drift is `Generating python code...` (lowercase, from the backend id) — the core no longer hardcodes "Python".
- Editor personas (Wren/Cody/Rex) intentionally left in `marsha/personas/`; the issue's leaf table and persona section scope reviewers only. Worth revisiting when Rust lands in #183.
- CI fix included: `meta.void_note`'s `MarshaMeta` annotation was an unquoted forward reference (defined below the class) — a `NameError` at import on 3.10–3.13 and an F821 under pyflakes. Now quoted.

Closes #204