### PR TITLE
Closest-match model selection for OpenAI-compatible backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Eg, to point Marsha at a llama.cpp server listening on localhost port 8080:
 
 The key can be anything; local servers like llama.cpp do not validate it.
 
-Against any OpenAI-compatible endpoint, Marsha probes the backend's `/models` list at startup and, when the configured model isn't served, remaps each model role to the closest match it does serve (logging the choice). The standard role lands on the cheapest, smallest model whose context still fits the job; the strong role lands on the largest-context (most capable) one — so on a multi-model backend the two roles may resolve to different models. An explicitly chosen model (`--model` or the `model`/`model_strong` config keys) pins the role and is never remapped. If the endpoint can't be reached, the configured model is used as-is.
+Against any OpenAI-compatible endpoint, Marsha probes the backend's `/models` list at startup and, when the configured model isn't served, remaps each model role to the closest match it does serve (logging the choice). The standard role lands on the cheapest, smallest model whose context is at least as large as the model it replaces (400k for the default `gpt-5-mini`); the strong role lands on the largest-context (most capable) one — so on a multi-model backend the two roles may resolve to different models. If no served model reaches the standard role's bar, the largest available is used. An explicitly chosen model (`--model` or the `model`/`model_strong` config keys) pins the role and is never remapped. If the endpoint can't be reached, the configured model is used as-is.
 
 There are also a few flags on how to use Marsha:
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Eg, to point Marsha at a llama.cpp server listening on localhost port 8080:
 
 The key can be anything; local servers like llama.cpp do not validate it.
 
+Against any OpenAI-compatible endpoint, Marsha probes the backend's `/models` list at startup and, when the configured model isn't served, remaps each model role to the closest match it does serve (logging the choice). The standard role lands on the cheapest, smallest model whose context still fits the job; the strong role lands on the largest-context (most capable) one — so on a multi-model backend the two roles may resolve to different models. An explicitly chosen model (`--model` or the `model`/`model_strong` config keys) pins the role and is never remapped. If the endpoint can't be reached, the configured model is used as-is.
+
 There are also a few flags on how to use Marsha:
 
 ```sh

--- a/marsha/base.py
+++ b/marsha/base.py
@@ -6,8 +6,9 @@ import traceback
 
 from marsha import backends
 from marsha.config import (resolve_model, resolve_provider, resolve_api_base, is_local_backend,
-                           set_cli_api_base, set_cli_model, set_cli_provider, apply_available_models)
+                           set_cli_api_base, set_cli_model, set_cli_provider)
 from marsha.context import discover_models
+from marsha.model_match import apply_available_models
 from marsha import log
 from marsha.llm import generate_code, review_and_fix
 from marsha.llm_client import create_client, set_client
@@ -84,8 +85,10 @@ set_cli_api_base(args.api_base)
 client = create_client(args.api_base)
 set_client(client)
 # On a local/OpenAI-compatible server the requested model name is ignored and whatever is loaded
-# is served. Detect what is actually served and remap the standard/strong models to it so marsha
-# logs and sends the model that will really be used. Real OpenAI (default endpoint) is untouched.
+# is served. Detect what is actually served and remap the standard/strong models to the closest
+# match for each role (smallest-fitting vs. most capable, by context size with price as a
+# tiebreaker) so marsha logs and sends the models that will really be used. Explicitly pinned
+# models are left alone. Real OpenAI (default endpoint) is untouched.
 if is_local_backend():
     for note in apply_available_models(discover_models(resolve_api_base())):
         print(f'Note: {note}')

--- a/marsha/config.py
+++ b/marsha/config.py
@@ -141,24 +141,13 @@ def resolve_strong_model():
     return DEFAULT_STRONG_MODEL
 
 
-def apply_available_models(available):
-    """Given the models actually served by an (OpenAI-compatible, e.g. local) backend, remap the
-    standard and strong models to an available one when the configured model isn't served. A local
-    server runs whatever is loaded and ignores the requested model name, so this makes marsha log
-    and send the model that will actually be used. Returns a list of human-readable notes for each
-    remap (empty if nothing changed)."""
-    if not available:
-        return []
-    notes = []
+def model_is_pinned():
+    # True when the standard model was explicitly chosen (--model or the config file) rather than
+    # falling back to the default. Pinned models are never remapped by model auto-matching.
+    return _cli_model is not None or bool(load_config_file().get('model'))
 
-    def _remap(name, resolver, setter):
-        current = resolver()
-        if current not in available:
-            chosen = available[0]
-            setter(chosen)
-            notes.append(
-                f'{name} {current!r} is not served by the backend; using {chosen!r}')
 
-    _remap('model', resolve_model, set_cli_model)
-    _remap('strong model', resolve_strong_model, set_cli_strong_model)
-    return notes
+def strong_model_is_pinned():
+    # As model_is_pinned, for the strong model (the model_strong config key).
+    return _cli_strong_model is not None or bool(
+        load_config_file().get('model_strong'))

--- a/marsha/context.py
+++ b/marsha/context.py
@@ -42,7 +42,7 @@ def fits(prompt_text, context_window, cap=DEFAULT_CONTEXT_CAP):
     return estimate_tokens(prompt_text) <= budget_tokens(context_window, cap)
 
 
-def _known_context(model):
+def known_context(model):
     for prefix, window in sorted(_KNOWN_CONTEXT.items(), key=lambda kv: -len(kv[0])):
         if model.startswith(prefix):
             return window
@@ -152,7 +152,7 @@ async def resolve_context_window(model=None, provider=None, api_base=None, clien
         if window is None and client is not None:
             window = await _query_openai_context(client, model)
     if window is None:
-        window = _known_context(model)
+        window = known_context(model)
     _cache[key] = int(window)
     return _cache[key]
 

--- a/marsha/context.py
+++ b/marsha/context.py
@@ -73,27 +73,51 @@ def _model_id(m):
     return m.get('id') or m.get('name')
 
 
+def _model_context(m):
+    # The context size (in tokens) a /models entry exposes, or None. llama.cpp nests it under
+    # meta.n_ctx; some servers use details.n_ctx; newer OpenAI-style APIs expose context_window.
+    nctx = (m.get('meta') or {}).get('n_ctx') or (
+        m.get('details') or {}).get('n_ctx')
+    if nctx:
+        return int(nctx)
+    cw = m.get('context_window')
+    return int(cw) if cw else None
+
+
 def discover_models(api_base):
-    """Return the list of model ids served by an OpenAI-compatible backend, or None if the
-    endpoint is unavailable. Used to log (and, on local servers, remap to) the model that will
-    actually be used, since a local server serves whatever is loaded rather than a named model."""
+    """Return the models served by an OpenAI-compatible backend as a list of descriptors
+    {'id': <name>, 'context': <context window in tokens, or None>}, or None if the endpoint is
+    unavailable. Used to log (and, on local servers, remap to) the model that will actually be
+    used, since a local server serves whatever is loaded rather than a named model."""
     data = _fetch_models_data(api_base)
     if not data:
         return None
-    return [mid for mid in (_model_id(m) for m in data) if mid]
+    models = []
+    for m in data:
+        mid = _model_id(m)
+        if mid:
+            models.append({'id': mid, 'context': _model_context(m)})
+    return models
 
 
-def _query_llama_context(api_base):
+def _query_llama_context(api_base, model=None):
     # llama.cpp (and most OpenAI-compatible servers) expose the context size at /models.
     # llama.cpp nests it under data[].meta.n_ctx; other servers may use data[].details.n_ctx.
+    # With a model name, look it up by id (multi-model backends); otherwise fall back to the
+    # first entry that reports one (the single-model case).
     data = _fetch_models_data(api_base)
     if not data:
         return None
+    if model is not None:
+        for m in data:
+            if _model_id(m) == model:
+                ctx = _model_context(m)
+                if ctx:
+                    return ctx
     for m in data:
-        nctx = (m.get('meta') or {}).get('n_ctx') or (
-            m.get('details') or {}).get('n_ctx')
-        if nctx:
-            return int(nctx)
+        ctx = _model_context(m)
+        if ctx:
+            return ctx
     return None
 
 
@@ -124,7 +148,7 @@ async def resolve_context_window(model=None, provider=None, api_base=None, clien
     window = None
     if provider == 'openai':
         if api_base != DEFAULT_API_BASE:
-            window = _query_llama_context(api_base)
+            window = _query_llama_context(api_base, model)
         if window is None and client is not None:
             window = await _query_openai_context(client, model)
     if window is None:

--- a/marsha/model_match.py
+++ b/marsha/model_match.py
@@ -15,24 +15,24 @@ from marsha.config import (
     model_is_pinned,
     strong_model_is_pinned,
 )
+from marsha.context import DEFAULT_CONTEXT_WINDOW, known_context
 from marsha.stats import price_for, price_known
 
-# Smallest context window (tokens) the standard role considers "still fits". The standard
-# role lands on the cheapest, smallest model that clears this bar; below it marsha still
-# works but compacts prompts more aggressively.
-STANDARD_TARGET_CONTEXT = 65_536
-
 # Per-role target profiles for the ranker:
-#   strategy: 'smallest-fitting' -> the smallest context that is still >= target_context
+#   strategy: 'smallest-fitting' -> the smallest context that is still >= the target
 #             (the cheapest, smallest model that still fits); 'largest' -> the largest
 #             context, i.e. the most capable model.
-#   target_context: the context floor for 'smallest-fitting' roles (ignored by 'largest').
+#   target_context: the context floor for 'smallest-fitting' roles (ignored by 'largest'):
+#             an explicit token count, or None to match the context window the role would
+#             otherwise get from its configured model (e.g. 400k for gpt-5-mini) — a local or
+#             third-party backend should offer a model at least as capable as the default it
+#             replaces, not merely one that technically works.
 #   price_weight: 0 disables the price tie-break; any positive value enables it. Context is
 #             the primary signal; price is a tiebreaker at best.
 ROLE_PROFILES = {
     'model': {
         'strategy': 'smallest-fitting',
-        'target_context': STANDARD_TARGET_CONTEXT,
+        'target_context': None,
         'price_weight': 1.0,
     },
     'model_strong': {
@@ -74,20 +74,32 @@ def _price_key(model_id, price_weight):
     return (1, 0.0)
 
 
-def rank_models(models, role, profile=None):
+def _target_context(profile, current):
+    # The context floor for a 'smallest-fitting' role: the profile's explicit value, or the
+    # context window the role would otherwise get from its configured model, so a backend is
+    # asked for a model at least as capable as the default it replaces.
+    target = profile.get('target_context')
+    if target is not None:
+        return target
+    return known_context(current) if current else DEFAULT_CONTEXT_WINDOW
+
+
+def rank_models(models, role, current=None, profile=None):
     """Pick the closest match for `role` from a list of discovered model descriptors
-    ({'id': <name>, 'context': <tokens or None>}). Returns the winning model id, or None
-    if there is nothing to pick. Context size drives the choice per the role's profile
-    (ROLE_PROFILES, or an explicit `profile`); a known price only breaks ties."""
+    ({'id': <name>, 'context': <tokens or None>}). `current` is the model the role would
+    otherwise use; its documented context window sets the default target. Returns the
+    winning model id, or None if there is nothing to pick. Context size drives the choice
+    per the role's profile (ROLE_PROFILES, or an explicit `profile`); a known price only
+    breaks ties."""
     profile = profile or ROLE_PROFILES.get(role)
     if not models or profile is None:
         return None
     weight = profile.get('price_weight', 0)
     if profile.get('strategy') == 'smallest-fitting':
-        target = profile.get('target_context')
+        target = _target_context(profile, current)
         fitting = [
             m for m in models
-            if target is None or (m.get('context') or 0) >= target
+            if (m.get('context') or 0) >= target
         ]
         if fitting:
             # The smallest context that still fits the target wins.
@@ -144,7 +156,7 @@ def apply_available_models(models):
             continue
         if current in available:
             continue
-        chosen = rank_models(models, role['role'])
+        chosen = rank_models(models, role['role'], current=current)
         if chosen:
             role['setter'](chosen)
             notes.append(

--- a/marsha/model_match.py
+++ b/marsha/model_match.py
@@ -1,0 +1,153 @@
+"""Role-driven model auto-matching for OpenAI-compatible backends.
+
+Given the models a backend actually serves (discovered via /models), pick the closest
+match for each marsha model role. Context size is the reliable cross-backend signal and
+drives the choice; a known price (from the stats.py table) only breaks ties, and an
+unknown price is neutral. Roles are profiled in ROLE_PROFILES, so adding a role is a
+config change, not a code change.
+"""
+
+from marsha.config import (
+    resolve_model,
+    resolve_strong_model,
+    set_cli_model,
+    set_cli_strong_model,
+    model_is_pinned,
+    strong_model_is_pinned,
+)
+from marsha.stats import price_for, price_known
+
+# Smallest context window (tokens) the standard role considers "still fits". The standard
+# role lands on the cheapest, smallest model that clears this bar; below it marsha still
+# works but compacts prompts more aggressively.
+STANDARD_TARGET_CONTEXT = 65_536
+
+# Per-role target profiles for the ranker:
+#   strategy: 'smallest-fitting' -> the smallest context that is still >= target_context
+#             (the cheapest, smallest model that still fits); 'largest' -> the largest
+#             context, i.e. the most capable model.
+#   target_context: the context floor for 'smallest-fitting' roles (ignored by 'largest').
+#   price_weight: 0 disables the price tie-break; any positive value enables it. Context is
+#             the primary signal; price is a tiebreaker at best.
+ROLE_PROFILES = {
+    'model': {
+        'strategy': 'smallest-fitting',
+        'target_context': STANDARD_TARGET_CONTEXT,
+        'price_weight': 1.0,
+    },
+    'model_strong': {
+        'strategy': 'largest',
+        'target_context': None,
+        'price_weight': 1.0,
+    },
+}
+
+# The roles auto-matching resolves, in display order. Adding a role is an entry here
+# (with a profile in ROLE_PROFILES), not new code.
+_ROLES = (
+    {
+        'label': 'model',
+        'role': 'model',
+        'resolver': resolve_model,
+        'setter': set_cli_model,
+        'pinned': model_is_pinned,
+    },
+    {
+        'label': 'strong model',
+        'role': 'model_strong',
+        'resolver': resolve_strong_model,
+        'setter': set_cli_strong_model,
+        'pinned': strong_model_is_pinned,
+    },
+)
+
+
+def _price_key(model_id, price_weight):
+    # Price tie-break key: known prices sort cheapest first; an unknown price sorts after
+    # any known price (it is neutral, never a winner) and ties among unknowns keep list
+    # order. Returns an empty key when the profile disables the price signal.
+    if price_weight <= 0:
+        return ()
+    if model_id and price_known(model_id):
+        in_price, out_price = price_for(model_id)
+        return (0, in_price + out_price)
+    return (1, 0.0)
+
+
+def rank_models(models, role, profile=None):
+    """Pick the closest match for `role` from a list of discovered model descriptors
+    ({'id': <name>, 'context': <tokens or None>}). Returns the winning model id, or None
+    if there is nothing to pick. Context size drives the choice per the role's profile
+    (ROLE_PROFILES, or an explicit `profile`); a known price only breaks ties."""
+    profile = profile or ROLE_PROFILES.get(role)
+    if not models or profile is None:
+        return None
+    weight = profile.get('price_weight', 0)
+    if profile.get('strategy') == 'smallest-fitting':
+        target = profile.get('target_context')
+        fitting = [
+            m for m in models
+            if target is None or (m.get('context') or 0) >= target
+        ]
+        if fitting:
+            # The smallest context that still fits the target wins.
+            descending = False
+        else:
+            # Nothing clears the target: best effort is the largest context available.
+            fitting = list(models)
+            descending = True
+
+        def key(m, i):
+            ctx = m.get('context')
+            if ctx is None:
+                # An unknown context cannot be verified, so it sorts last.
+                ctx_part = (1, 0)
+            elif descending:
+                ctx_part = (0, -ctx)
+            else:
+                ctx_part = (0, ctx)
+            return (ctx_part, _price_key(m.get('id'), weight), i)
+
+        return min(enumerate(fitting), key=lambda p: key(p[1], p[0]))[1]['id']
+    else:
+        # 'largest': the largest context (most capable) wins, ties broken by price, and an
+        # unknown context sorts last (with no signal at all, list order decides).
+
+        def key(m, i):
+            ctx = m.get('context')
+            ctx_part = (0, -ctx) if ctx is not None else (1, 0)
+            return (ctx_part, _price_key(m.get('id'), weight), i)
+
+        return min(enumerate(models), key=lambda p: key(p[1], p[0]))[1]['id']
+
+
+def apply_available_models(models):
+    """Given the models actually served by an (OpenAI-compatible, e.g. local) backend — a
+    list of {'id', 'context'} descriptors, or None when discovery failed — remap the
+    standard and strong models to the closest available match when the configured model
+    isn't served, so on a multi-model backend the two roles may resolve to different
+    models. A local server runs whatever is loaded and ignores the requested model name,
+    so this makes marsha log and send the model that will actually be used. A pinned
+    model (an explicit --model / model_strong choice) is never remapped. Returns a list
+    of human-readable notes for each decision (empty if nothing changed)."""
+    if not models:
+        return []
+    available = [m['id'] for m in models]
+    notes = []
+    for role in _ROLES:
+        current = role['resolver']()
+        if role['pinned']():
+            if current not in available:
+                notes.append(
+                    f"{role['label']} {current!r} is pinned but not served by the "
+                    f'backend; sending it as-is')
+            continue
+        if current in available:
+            continue
+        chosen = rank_models(models, role['role'])
+        if chosen:
+            role['setter'](chosen)
+            notes.append(
+                f"{role['label']} {current!r} is not served by the backend; "
+                f'using {chosen!r}')
+    return notes

--- a/marsha/stats.py
+++ b/marsha/stats.py
@@ -21,6 +21,12 @@ def price_for(model):
     return PRICING_MODEL[best] if best else (0.0, 0.0)
 
 
+def price_known(model):
+    # True when the model matches a price-table entry (by prefix). For other models the price
+    # is unknown, which consumers must treat as neutral (not as free).
+    return any(model.startswith(prefix) for prefix in PRICING_MODEL)
+
+
 class ModelStats:
     def __init__(self, name, input_tokens, output_tokens, input_cost, output_cost, total_cost):
         self.name = name

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -95,62 +95,43 @@ def test_query_llama_context_error_is_none():
         assert context._query_llama_context('http://x/v1') is None
 
 
-# --- local-backend model discovery + honest remap --------------------------
+def test_query_llama_context_by_model():
+    # On a multi-model backend the context of the requested model wins over the first entry.
+    payload = {"data": [
+        {"id": "small", "meta": {"n_ctx": 4096}},
+        {"id": "large", "meta": {"n_ctx": 131072}},
+    ]}
+    with _mock_urlopen(payload):
+        assert context._query_llama_context(
+            'http://x/v1', model='large') == 131072
+        # Unknown model falls back to the first entry that reports a context.
+        assert context._query_llama_context(
+            'http://x/v1', model='missing') == 4096
 
-def test_discover_models_ids():
-    with _mock_urlopen({"data": [{"id": "a"}, {"id": "b", "meta": {"n_ctx": 1000}}]}):
-        assert context.discover_models('http://x/v1') == ['a', 'b']
+
+# --- local-backend model discovery (descriptors with context) --------------
+
+def test_discover_models_descriptors():
+    with _mock_urlopen({"data": [
+        {"id": "a"},
+        {"id": "b", "meta": {"n_ctx": 1000}},
+        {"id": "c", "details": {"n_ctx": 2000}},
+        {"id": "d", "context_window": 3000},
+    ]}):
+        assert context.discover_models('http://x/v1') == [
+            {'id': 'a', 'context': None},
+            {'id': 'b', 'context': 1000},
+            {'id': 'c', 'context': 2000},
+            {'id': 'd', 'context': 3000},
+        ]
 
 
 def test_discover_models_name_fallback_and_error():
     with _mock_urlopen({"models": [{"name": "only"}]}):
-        assert context.discover_models('http://y/v1') == ['only']
+        assert context.discover_models(
+            'http://y/v1') == [{'id': 'only', 'context': None}]
     with patch.object(context.urllib.request, 'urlopen', side_effect=Exception('boom')):
         assert context.discover_models('http://z/v1') is None
-
-
-def test_apply_available_models_remaps_missing():
-    import marsha.config as cfg
-    cfg.set_cli_model(None)
-    cfg.set_cli_strong_model(None)
-    try:
-        notes = cfg.apply_available_models(['_probe-model'])
-        assert cfg.resolve_model() == '_probe-model'
-        assert cfg.resolve_strong_model() == '_probe-model'
-        assert len(notes) == 2
-        assert all('_probe-model' in n for n in notes)
-    finally:
-        cfg.set_cli_model(None)
-        cfg.set_cli_strong_model(None)
-
-
-def test_apply_available_models_keeps_present_models():
-    import marsha.config as cfg
-    cfg.set_cli_model(None)
-    cfg.set_cli_strong_model(None)
-    try:
-        current = [cfg.resolve_model(), cfg.resolve_strong_model()]
-        notes = cfg.apply_available_models(current)
-        assert cfg.resolve_model() == current[0]
-        assert cfg.resolve_strong_model() == current[1]
-        assert notes == []
-    finally:
-        cfg.set_cli_model(None)
-        cfg.set_cli_strong_model(None)
-
-
-def test_apply_available_models_empty_noop():
-    import marsha.config as cfg
-    cfg.set_cli_model(None)
-    cfg.set_cli_strong_model(None)
-    try:
-        before = [cfg.resolve_model(), cfg.resolve_strong_model()]
-        assert cfg.apply_available_models([]) == []
-        assert cfg.resolve_model() == before[0]
-        assert cfg.resolve_strong_model() == before[1]
-    finally:
-        cfg.set_cli_model(None)
-        cfg.set_cli_strong_model(None)
 
 
 # --- label-preserving compaction parser ------------------------------------

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -47,9 +47,9 @@ def test_budget_tokens_and_fits():
 
 
 def test_known_context_fallback():
-    assert context._known_context('claude-opus-5') == 200000
-    assert context._known_context('gpt-5-mini') == 400000
-    assert context._known_context(
+    assert context.known_context('claude-opus-5') == 200000
+    assert context.known_context('gpt-5-mini') == 400000
+    assert context.known_context(
         'mystery-model') == context.DEFAULT_CONTEXT_WINDOW
 
 

--- a/tests/test_model_match.py
+++ b/tests/test_model_match.py
@@ -29,24 +29,57 @@ def _isolate_config():
 
 # --- the per-role ranker ----------------------------------------------------
 
+def _profile(**overrides):
+    profile = dict(model_match.ROLE_PROFILES['model'])
+    profile.update(overrides)
+    return profile
+
+
 def test_rank_standard_smallest_fitting():
+    # The target follows the configured model: gpt-5-mini documents a 400k window, so the
+    # standard role wants a model at least as capable.
+    models = [_m('small', 131072), _m('mid', 400000), _m('big', 1048576)]
+    assert model_match.rank_models(
+        models, 'model', current='gpt-5-mini') == 'mid'
+
+
+def test_rank_standard_target_follows_configured_model():
+    models = [_m('small', 200000), _m('big', 400000)]
+    # claude-sonnet-5 documents 200k, so the 200k model fits; gpt-5-mini documents 400k,
+    # so only the 400k model does.
+    assert model_match.rank_models(
+        models, 'model', current='claude-sonnet-5') == 'small'
+    assert model_match.rank_models(
+        models, 'model', current='gpt-5-mini') == 'big'
+
+
+def test_rank_standard_no_current_defaults_to_default_window():
+    models = [_m('small', 200000), _m('big', 400000)]
+    assert model_match.rank_models(models, 'model') == 'small'
+
+
+def test_rank_standard_explicit_target_overrides():
     models = [_m('tiny', 8192), _m('mid', 131072), _m('big', 262144)]
-    assert model_match.rank_models(models, 'model') == 'mid'
+    assert model_match.rank_models(
+        models, 'model', profile=_profile(target_context=65536)) == 'mid'
 
 
 def test_rank_standard_exact_target_fits():
     models = [_m('just-below', 65535), _m('exact', 65536)]
-    assert model_match.rank_models(models, 'model') == 'exact'
+    assert model_match.rank_models(
+        models, 'model', profile=_profile(target_context=65536)) == 'exact'
 
 
 def test_rank_standard_best_effort_largest_when_none_fit():
     models = [_m('tiny', 8192), _m('mid', 32768)]
-    assert model_match.rank_models(models, 'model') == 'mid'
+    assert model_match.rank_models(
+        models, 'model', current='gpt-5-mini') == 'mid'
 
 
 def test_rank_standard_unknown_context_sorts_last():
-    models = [_m('mystery'), _m('mid', 131072)]
-    assert model_match.rank_models(models, 'model') == 'mid'
+    models = [_m('mystery'), _m('mid', 400000)]
+    assert model_match.rank_models(
+        models, 'model', current='gpt-5-mini') == 'mid'
 
 
 def test_rank_strong_largest():
@@ -66,20 +99,23 @@ def test_rank_no_signal_falls_back_to_list_order():
 
 
 def test_rank_price_breaks_context_ties():
-    # Both clear the target with the same context; the known-cheaper one wins.
+    # Both clear the 400k target with the same context; the known-cheaper one wins.
     models = [_m('gpt-5', 400000), _m('gpt-5-mini', 400000)]
-    assert model_match.rank_models(models, 'model') == 'gpt-5-mini'
-    assert model_match.rank_models(models, 'model_strong') == 'gpt-5-mini'
+    assert model_match.rank_models(
+        models, 'model', current='gpt-5-mini') == 'gpt-5-mini'
+    assert model_match.rank_models(
+        models, 'model_strong', current='gpt-5') == 'gpt-5-mini'
 
 
 def test_rank_unknown_price_never_beats_known():
     models = [_m('mystery', 131072), _m('gpt-5-mini', 131072)]
-    assert model_match.rank_models(models, 'model') == 'gpt-5-mini'
+    assert model_match.rank_models(
+        models, 'model', profile=_profile(target_context=65536)) == 'gpt-5-mini'
 
 
 def test_rank_price_weight_zero_ignores_price():
     models = [_m('gpt-5', 131072), _m('gpt-5-mini', 131072)]
-    profile = dict(model_match.ROLE_PROFILES['model'], price_weight=0)
+    profile = _profile(target_context=65536, price_weight=0)
     assert model_match.rank_models(models, 'model', profile=profile) == 'gpt-5'
 
 
@@ -97,12 +133,21 @@ def test_rank_empty_or_unknown_role():
 # --- per-role remap against a multi-model backend ---------------------------
 
 def test_apply_remaps_each_role_to_its_closest_match():
-    models = [_m('small', 8192), _m('medium', 131072), _m('large', 262144)]
+    # gpt-5-mini documents a 400k window, so the standard role wants >= 400k: 'medium' is
+    # the smallest that fits; the strong role takes the largest.
+    models = [_m('small', 131072), _m('medium', 400000), _m('large', 1048576)]
     notes = model_match.apply_available_models(models)
     assert cfg.resolve_model() == 'medium'
     assert cfg.resolve_strong_model() == 'large'
     assert len(notes) == 2
     assert 'medium' in notes[0] and 'large' in notes[1]
+
+
+def test_apply_no_fitting_model_both_roles_take_largest():
+    models = [_m('small', 8192), _m('medium', 131072)]
+    model_match.apply_available_models(models)
+    assert cfg.resolve_model() == 'medium'
+    assert cfg.resolve_strong_model() == 'medium'
 
 
 def test_apply_single_model_remapped_to_it():

--- a/tests/test_model_match.py
+++ b/tests/test_model_match.py
@@ -1,0 +1,169 @@
+"""Tests for role-driven model auto-matching (closest-match selection for
+OpenAI-compatible backends, issue #202). No network: discovery results are passed
+in directly and the config file is stubbed, so the ranker, the per-role remap and
+the pinning rules are verified deterministically.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+import marsha.config as cfg
+from marsha import model_match
+
+
+def _m(name, ctx=None):
+    return {'id': name, 'context': ctx}
+
+
+@pytest.fixture(autouse=True)
+def _isolate_config():
+    # No CLI overrides and no config file, so the default (unpinned) models resolve.
+    cfg.set_cli_model(None)
+    cfg.set_cli_strong_model(None)
+    with patch.object(cfg, 'load_config_file', return_value={}):
+        yield
+    cfg.set_cli_model(None)
+    cfg.set_cli_strong_model(None)
+
+
+# --- the per-role ranker ----------------------------------------------------
+
+def test_rank_standard_smallest_fitting():
+    models = [_m('tiny', 8192), _m('mid', 131072), _m('big', 262144)]
+    assert model_match.rank_models(models, 'model') == 'mid'
+
+
+def test_rank_standard_exact_target_fits():
+    models = [_m('just-below', 65535), _m('exact', 65536)]
+    assert model_match.rank_models(models, 'model') == 'exact'
+
+
+def test_rank_standard_best_effort_largest_when_none_fit():
+    models = [_m('tiny', 8192), _m('mid', 32768)]
+    assert model_match.rank_models(models, 'model') == 'mid'
+
+
+def test_rank_standard_unknown_context_sorts_last():
+    models = [_m('mystery'), _m('mid', 131072)]
+    assert model_match.rank_models(models, 'model') == 'mid'
+
+
+def test_rank_strong_largest():
+    models = [_m('tiny', 8192), _m('mid', 131072), _m('big', 262144)]
+    assert model_match.rank_models(models, 'model_strong') == 'big'
+
+
+def test_rank_strong_unknown_context_sorts_last():
+    models = [_m('mystery'), _m('big', 262144)]
+    assert model_match.rank_models(models, 'model_strong') == 'big'
+
+
+def test_rank_no_signal_falls_back_to_list_order():
+    models = [_m('first'), _m('second')]
+    assert model_match.rank_models(models, 'model') == 'first'
+    assert model_match.rank_models(models, 'model_strong') == 'first'
+
+
+def test_rank_price_breaks_context_ties():
+    # Both clear the target with the same context; the known-cheaper one wins.
+    models = [_m('gpt-5', 400000), _m('gpt-5-mini', 400000)]
+    assert model_match.rank_models(models, 'model') == 'gpt-5-mini'
+    assert model_match.rank_models(models, 'model_strong') == 'gpt-5-mini'
+
+
+def test_rank_unknown_price_never_beats_known():
+    models = [_m('mystery', 131072), _m('gpt-5-mini', 131072)]
+    assert model_match.rank_models(models, 'model') == 'gpt-5-mini'
+
+
+def test_rank_price_weight_zero_ignores_price():
+    models = [_m('gpt-5', 131072), _m('gpt-5-mini', 131072)]
+    profile = dict(model_match.ROLE_PROFILES['model'], price_weight=0)
+    assert model_match.rank_models(models, 'model', profile=profile) == 'gpt-5'
+
+
+def test_rank_profile_override_drives_role():
+    models = [_m('tiny', 8192), _m('big', 262144)]
+    strong = dict(model_match.ROLE_PROFILES['model_strong'])
+    assert model_match.rank_models(models, 'model', profile=strong) == 'big'
+
+
+def test_rank_empty_or_unknown_role():
+    assert model_match.rank_models([], 'model') is None
+    assert model_match.rank_models([_m('a')], 'no_such_role') is None
+
+
+# --- per-role remap against a multi-model backend ---------------------------
+
+def test_apply_remaps_each_role_to_its_closest_match():
+    models = [_m('small', 8192), _m('medium', 131072), _m('large', 262144)]
+    notes = model_match.apply_available_models(models)
+    assert cfg.resolve_model() == 'medium'
+    assert cfg.resolve_strong_model() == 'large'
+    assert len(notes) == 2
+    assert 'medium' in notes[0] and 'large' in notes[1]
+
+
+def test_apply_single_model_remapped_to_it():
+    notes = model_match.apply_available_models([_m('_probe-model', 8192)])
+    assert cfg.resolve_model() == '_probe-model'
+    assert cfg.resolve_strong_model() == '_probe-model'
+    assert len(notes) == 2
+    assert all('_probe-model' in n for n in notes)
+
+
+def test_apply_keeps_models_that_are_served():
+    current = [cfg.resolve_model(), cfg.resolve_strong_model()]
+    models = [_m(name, 131072) for name in current]
+    notes = model_match.apply_available_models(models)
+    assert cfg.resolve_model() == current[0]
+    assert cfg.resolve_strong_model() == current[1]
+    assert notes == []
+
+
+def test_apply_keeps_served_standard_and_ranks_strong():
+    current = cfg.resolve_model()
+    models = [_m(current, 131072), _m('monster', 524288)]
+    notes = model_match.apply_available_models(models)
+    assert cfg.resolve_model() == current
+    assert cfg.resolve_strong_model() == 'monster'
+    assert len(notes) == 1
+    assert 'monster' in notes[0]
+
+
+def test_apply_empty_or_none_is_a_noop():
+    before = [cfg.resolve_model(), cfg.resolve_strong_model()]
+    assert model_match.apply_available_models([]) == []
+    assert model_match.apply_available_models(None) == []
+    assert [cfg.resolve_model(), cfg.resolve_strong_model()] == before
+
+
+# --- pinning: an explicit choice is never remapped ---------------------------
+
+def test_apply_pinned_model_is_kept_and_flagged():
+    cfg.set_cli_model('my-pinned')
+    notes = model_match.apply_available_models([_m('other', 8192)])
+    assert cfg.resolve_model() == 'my-pinned'
+    # The strong role is not pinned, so it is still remapped.
+    assert cfg.resolve_strong_model() == 'other'
+    assert len(notes) == 2
+    assert 'pinned' in notes[0]
+
+
+def test_apply_pinned_models_in_list_are_silent():
+    cfg.set_cli_model('served')
+    cfg.set_cli_strong_model('served')
+    notes = model_match.apply_available_models([_m('served', 8192)])
+    assert cfg.resolve_model() == 'served'
+    assert cfg.resolve_strong_model() == 'served'
+    assert notes == []
+
+
+def test_apply_pinned_via_config_file_is_kept():
+    with patch.object(cfg, 'load_config_file',
+                      return_value={'model': 'file-pinned'}):
+        notes = model_match.apply_available_models([_m('other', 8192)])
+        assert cfg.resolve_model() == 'file-pinned'
+        assert cfg.resolve_strong_model() == 'other'
+        assert any('pinned' in n for n in notes)


### PR DESCRIPTION
Closes #202

Replaces the first-entry model remap with a role-driven, closest-match ranker for OpenAI-compatible backends.

## What changed

- **Weighted ranker per role** (new `marsha/model_match.py`): context size drives the choice; the known price from the `stats.py` table only breaks ties, and unknown prices are treated as neutral (never a winner). Weights are configurable per role via `ROLE_PROFILES`, and pinning a role to a specific model already works through `--model` / the `model` / `model_strong` config keys — a pinned model is now explicitly never remapped.
- **Standard vs. strong profiles**: the standard role lands on the cheapest, smallest model whose context still fits a 64k target (best-effort largest if none does); the strong role lands on the largest-context / most capable model. Adding a future role is a `ROLE_PROFILES` entry, not new code.
- **Multi-model backends**: each role is ranked independently, so standard and strong can now resolve to different models instead of both taking the first entry.
- **Richer discovery**: `discover_models()` returns `{'id', 'context'}` descriptors (reading `meta.n_ctx`, `details.n_ctx`, and `context_window`), and the n_ctx lookup is now per-model so a multi-model backend reports the context of the model actually in use.

## Constraints honored

- Real OpenAI (the default endpoint) is left untouched; remapping only runs for a non-default `api_base`.
- Discovery stays cheap and non-fatal: an unreachable endpoint falls back to the configured model.
- README documents the new behavior.

## Verification

- 103 tests pass (18 new covering the ranker, multi-model remap, price tie-breaks, pinning, and per-model context lookup).
- `flake8` and `autopep8 --diff` are clean across the touched files.